### PR TITLE
DTO 타입에 따른 Query재 작성

### DIFF
--- a/src/channels/channels.repository.ts
+++ b/src/channels/channels.repository.ts
@@ -4,7 +4,7 @@ import { DataSource, Repository } from 'typeorm';
 import { DBUpdateFailureException } from '../common/exception/custom-exception';
 import { ChannelUser } from './entities/channel-user.entity';
 import { Channel } from './entities/channel.entity';
-
+import { User } from 'src/users/entities/user.entity';
 export class ChannelsRepository extends Repository<Channel> {
 	constructor(@InjectRepository(Channel) private dataSource: DataSource) {
 		super(Channel, dataSource.manager);
@@ -48,10 +48,13 @@ export class ChannelsRepository extends Repository<Channel> {
 	){
 		const channels = await this.dataSource.query(
 			`
-			SELECT "channelId", "name", "channelType"
+			SELECT "channelId", "name", "channelType", count("userId") as "userCount"
 			FROM Channel c JOIN channel_user cu
 			ON c.id = cu."channelId"
-			WHERE c."deletedAt" IS NULL
+			WHERE c."deletedAt" IS NULL 
+			AND c."channelType" != 'PRIVATE'
+			GROUP BY "channelId", "name", "channelType"
+			ORDER BY c."channelType" DESC
 			LIMIT $1 OFFSET $2;
 			`,
 			[DEFAULT_PAGE_SIZE, (page - 1) * DEFAULT_PAGE_SIZE],
@@ -66,19 +69,18 @@ export class ChannelsRepository extends Repository<Channel> {
 	){
 		const channels = await this.dataSource.query(
 			`
-			SELECT "channelId", "name", "channelType"
+			SELECT "channelId", "name", "channelType", count("userId") as "userCount"
 			FROM Channel c JOIN channel_user cu
 			ON c.id = cu."channelId"
 			WHERE cu."userId" = $1
 			AND c."deletedAt" IS NULL
+			GROUP BY "channelId", "name", "channelType"
 			ORDER BY c."channelType" DESC
 			LIMIT $2 OFFSET $3;
 			`,
 			[userId, DEFAULT_PAGE_SIZE, (page - 1) * DEFAULT_PAGE_SIZE],
 		);
 		
-		console.log("channels: ", channels);
-
 		return channels;
 	}
 
@@ -88,13 +90,17 @@ export class ChannelsRepository extends Repository<Channel> {
 	){
 		const channels = await this.dataSource.query(
 			`
-			SELECT "channelId", "name", "channelType"
-			FROM Channel c JOIN channel_user cu
-			ON c.id = cu."channelId"
-			WHERE c."channelType" = 'DM'
-			AND cu."userId" = $1
-			AND c."deletedAt" IS NULL
-			LIMIT $2 OFFSET $3;
+			SELECT "channelId", "partnerName", "status"
+			FROM User u JOIN channel_user cu
+			ON u.id = cu."userId"
+			WHERE cu."channelId" IN
+				(SELECT c.id
+				FROM channel_user cu2
+						JOIN channel c
+							ON cu2."channelId" = c.id
+				WHERE cu2."userId" = $1
+					AND c."channelType" = 'DM'
+					AND c."deletedAt" IS NULL)
 			`,
 			[userId, DEFAULT_PAGE_SIZE, (page - 1) * DEFAULT_PAGE_SIZE],
 		);

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -292,7 +292,11 @@ export class ChannelsService {
 		const channels: ChannelListReturnDto[] = await this.channelsRepository.findAllChannels(
 			page,
 		);
-		const totalDataSize: number = await this.channelsRepository.count();
+		const totalDataSize: number = await this.channelsRepository.count({
+			where: {
+				channelType: ChannelType.PUBLIC || ChannelType.PROTECTED,
+			},
+		});
 		if (!channels) {
 			throw new InternalServerErrorException(`There is no channel`);
 		};
@@ -323,7 +327,11 @@ export class ChannelsService {
 			userId,
 			page,
 		);
-		const totalItemCount: number = await this.channelsRepository.count();
+		const totalItemCount: number = await this.channelsRepository.count({
+			where: {
+				channelType: ChannelType.DM,
+			},
+		});
 		if (!dmChannels) {
 			throw new InternalServerErrorException(`There is no 'dm channel'`);
 		};

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -292,7 +292,7 @@ export class ChannelsService {
 		const channels: ChannelListReturnDto[] = await this.channelsRepository.findAllChannels(
 			page,
 		);
-		const totalDataSize: number = await channels.length;
+		const totalDataSize: number = await this.channelsRepository.count();
 		if (!channels) {
 			throw new InternalServerErrorException(`There is no channel`);
 		};
@@ -307,7 +307,7 @@ export class ChannelsService {
 			userId,
 			page,
 		);
-		const totalDataSize: number = await channels.length;
+		const totalDataSize: number = await this.channelsRepository.count();
 		if (!channels) {
 			throw new InternalServerErrorException(`There is no 'my channel'`);
 		};
@@ -323,7 +323,7 @@ export class ChannelsService {
 			userId,
 			page,
 		);
-		const totalItemCount: number = await dmChannels.length;
+		const totalItemCount: number = await this.channelsRepository.count();
 		if (!dmChannels) {
 			throw new InternalServerErrorException(`There is no 'dm channel'`);
 		};


### PR DESCRIPTION
주요 변경점
< totalDataSize >
before: 프론트에서 totalDataSize를 통해 전체값을 리턴해주어야 하는데, 페이지네이션 된 카운트만 리턴해주었음
after: totalDataSize에서 전체값을 리턴해주도록 변경

< userCount >
쿼리문에 유저 카운트를 가지고 오지 못하는 문제점이 있어서 groupby를 통해 집계함수를 사용함

< DMCount >
User 테이블과 Channel user 테이블 그리고 channel 테이블의 조인
cu."channelId", cu."userId" as "PartnerName", u."status" 로 가지고 오도록 변경