### PR TITLE
fix: add channelId validation and modify findAllChannel query

### DIFF
--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -118,8 +118,9 @@ export class ChannelsController {
 	@Patch('/exit')
 	async updateChannelUser(
 		@GetUser() user: User,
-		@Body('channelId') channelId: number,
+		@Body('channelId', ParseIntPipe, PositiveIntPipe) channelId: number,
 	) {
+		console.log(channelId);
 		await this.channelsService.updateChannelUser(user.id, channelId);
 	}
 

--- a/src/channels/channels.repository.ts
+++ b/src/channels/channels.repository.ts
@@ -46,6 +46,7 @@ export class ChannelsRepository extends Repository<Channel> {
 			WHERE c."deletedAt" IS NULL 
 			AND c."channelType" != 'PRIVATE' 
 			AND c."channelType" != 'DM'
+			AND cu."deletedAt" IS NULL
 			GROUP BY "channelId", "name", "channelType"
 			LIMIT $1 OFFSET $2;
 			`,
@@ -90,10 +91,7 @@ export class ChannelsRepository extends Repository<Channel> {
 		return realSize;
 	}
 
-	async findDmChannels(
-		userId: number,
-		page: number,
-	){
+	async findDmChannels(userId: number, page: number) {
 		const channels = await this.dataSource.query(
 			`
 			SELECT cu."channelId", cu."userId" as "PartnerName", u."status"

--- a/src/channels/dto/update-channel-user-request.dto.ts
+++ b/src/channels/dto/update-channel-user-request.dto.ts
@@ -1,8 +1,6 @@
 import { IsNotEmpty, IsNumber, IsPositive } from 'class-validator';
-import { Column } from 'typeorm';
 
 export class UpdateChannelUserRequestDto {
-	@Column()
 	@IsNumber()
 	@IsPositive()
 	@IsNotEmpty()


### PR DESCRIPTION
- PATCH /channels/exit  
    - api call 시 request body의 channelId 유효성 검사를 하고있지 않아 추가했습니다.
- GET /channels/all
    - api call 시 response data인 userCount 값을 구할 때 채널을 나간 유저까지 합계하는 것을 수정했습니다.