### PR TITLE
feat: update user ranking data for every 10minute  #56

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"@nestjs/passport": "^10.0.2",
 				"@nestjs/platform-express": "^9.0.0",
 				"@nestjs/platform-socket.io": "^9.4.3",
+				"@nestjs/schedule": "^4.0.0",
 				"@nestjs/swagger": "^7.1.16",
 				"@nestjs/typeorm": "^10.0.0",
 				"@nestjs/websockets": "^9.4.3",
@@ -1957,6 +1958,32 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
 			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
 		},
+		"node_modules/@nestjs/schedule": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.0.0.tgz",
+			"integrity": "sha512-zz4h54m/F/1qyQKvMJCRphmuwGqJltDAkFxUXCVqJBXEs5kbPt93Pza3heCQOcMH22MZNhGlc9DmDMLXVHmgVQ==",
+			"dependencies": {
+				"cron": "3.1.3",
+				"uuid": "9.0.1"
+			},
+			"peerDependencies": {
+				"@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+				"@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+				"reflect-metadata": "^0.1.12"
+			}
+		},
+		"node_modules/@nestjs/schedule/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/@nestjs/schematics": {
 			"version": "9.2.0",
 			"resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-9.2.0.tgz",
@@ -2489,6 +2516,11 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/luxon": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.6.tgz",
+			"integrity": "sha512-LblarKeI26YsMLxHDIQ0295wPSLjkl98eNwDcVhz3zbo1H+kfnkzR01H5Ai5LBzSeddX0ZJSpGwKEZihGb5diw=="
 		},
 		"node_modules/@types/mime": {
 			"version": "1.3.5",
@@ -4105,6 +4137,15 @@
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"devOptional": true
+		},
+		"node_modules/cron": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/cron/-/cron-3.1.3.tgz",
+			"integrity": "sha512-KVxeKTKYj2eNzN4ElnT6nRSbjbfhyxR92O/Jdp6SH3pc05CDJws59jBrZWEMQlxevCiE6QUTrXy+Im3vC3oD3A==",
+			"dependencies": {
+				"@types/luxon": "~3.3.0",
+				"luxon": "~3.4.0"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -6926,6 +6967,14 @@
 			"integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
 			"engines": {
 				"node": "14 || >=16.14"
+			}
+		},
+		"node_modules/luxon": {
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+			"integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/macos-release": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@nestjs/passport": "^10.0.2",
 		"@nestjs/platform-express": "^9.0.0",
 		"@nestjs/platform-socket.io": "^9.4.3",
+		"@nestjs/schedule": "^4.0.0",
 		"@nestjs/swagger": "^7.1.16",
 		"@nestjs/typeorm": "^10.0.0",
 		"@nestjs/websockets": "^9.4.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import redisConfig from './config/redis.config';
 import typeOrmConfig from './config/typeorm.config';
 import { GameModule } from './game/game.module';
 import { UsersModule } from './users/users.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
 	imports: [
@@ -43,6 +44,7 @@ import { UsersModule } from './users/users.module';
 			useFactory: (redisConfigure: ConfigType<typeof redisConfig>) =>
 				redisConfigure,
 		}),
+		ScheduleModule.forRoot(),
 		AuthModule,
 		UsersModule,
 		GameModule,

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
 import { Redis } from 'ioredis';
-
+import { Logger } from '@nestjs/common';
 @Injectable()
 export class AppService {
 	constructor(@InjectRedis() private readonly redis: Redis) {}
 
 	// push data to redis using zadd
-	async updateRanking(id: number, score: number) {
-		await this.redis.zadd('rankings', score, `user:${id}`);
+	async updateRanking(score: number, id: number) {
+		Logger.log(`Redis updateRanking: ${score}, ${id}`)
+		await this.redis.zadd('rankings', score, id);
 	}
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Patch, Post, Res, UseGuards } from '@nestjs/common';
+import { AppService } from './../app.service';
+import { Body, Controller, Logger, Patch, Post, Res, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 import { User } from 'src/users/entities/user.entity';
@@ -17,6 +18,7 @@ export class AuthController {
 		private readonly authService: AuthService,
 		private readonly ftAuthService: FtAuthService,
 		private readonly usersService: UsersService,
+		private readonly AppService: AppService,
 	) {}
 
 	@Post('/signin')
@@ -127,7 +129,7 @@ export class AuthController {
 		}
 
 		const user = await this.usersService.createUser(nickname, 'test@test');
-
+		
 		const { jwtAccessToken, jwtRefreshToken } =
 			await this.authService.generateJwtToken(user);
 
@@ -152,6 +154,8 @@ export class AuthController {
 			isMfaEnabled: false,
 			mfaCode: undefined,
 		};
+		Logger.log(`updateRanking(ladderScore, id): ${user.ladderScore}, ${user.id}`);
+		await this.AppService.updateRanking(user.ladderScore, user.id);
 
 		return res.send(userSigninResponseDto);
 	}
@@ -162,7 +166,7 @@ export class AuthController {
 		description:
 			'200 OK 만 반환한다. 쿠키에 있는 access,refresh token를 지운다.',
 	})
-	@UseGuards(JwtAuthGuard)
+	@UseGuards(JwtAuthGuard)	
 	async signout(@GetUser() user: User, @Res() res: Response) {
 		await this.usersService.signout(user.id);
 

--- a/src/users/ranks.service.ts
+++ b/src/users/ranks.service.ts
@@ -18,17 +18,13 @@ export class RanksService {
 		//userIDRanking: [userId, userId, userId, ...]
 		
 
-		const userRanking = await this.redis.zrange(
+		const userRanking = await this.redis.zrevrange(
 			'rankings',
 			(page - 1) * 10,
 			page * 10 - 1,
 		);
 
-		// console.log('userranking', userRanking);
-
-		if (!userRanking) {
-			throw new BadRequestException(`unavailable ranking property`);
-		}
+		console.log('userranking', userRanking); // ok
 
 		const foundUsers = await this.userRepository.findRanksInfos(
 			userRanking,
@@ -48,7 +44,7 @@ export class RanksService {
 		return { rankUsers, totalItemCount };
 	}
 
-	@Cron(CronExpression.EVERY_10_MINUTES)
+	@Cron(CronExpression.EVERY_MINUTE)
 	async handleCron() {
 		const users = await this.userRepository.find();
 		for (const user of users) {

--- a/src/users/ranks.service.ts
+++ b/src/users/ranks.service.ts
@@ -1,34 +1,34 @@
+import { AppService } from 'src/app.service';
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { Redis } from 'ioredis';
 import { UsersRepository } from 'src/users/users.repository';
 import { RankUserResponseDto } from './dto/rank-user-response.dto';
 import { RankUserReturnDto } from './dto/rank-user-return.dto';
-
+import { Cron, CronExpression } from '@nestjs/schedule';
 @Injectable()
 export class RanksService {
 	constructor(
 		private readonly userRepository: UsersRepository,
+		private readonly AppService: AppService,
 		@InjectRedis() private readonly redis: Redis,
 	) {}
 
 	async findRanksWithPage(page: number): Promise<RankUserResponseDto> {
 		//userIDRanking: [userId, userId, userId, ...]
-		// const userRanking: string[] = await this.redis.zrange(
-		// 	'rankings',
-		// 	(page - 1) * 10,
-		// 	page * 10 - 1,
-		// );
+		
+
 		const userRanking = await this.redis.zrange(
 			'rankings',
 			(page - 1) * 10,
 			page * 10 - 1,
 		);
 
+		// console.log('userranking', userRanking);
+
 		if (!userRanking) {
 			throw new BadRequestException(`unavailable ranking property`);
 		}
-		console.log('userRanking: ', userRanking); // dbg
 
 		const foundUsers = await this.userRepository.findRanksInfos(
 			userRanking,
@@ -39,12 +39,21 @@ export class RanksService {
 		// userID 배열을 가지고 유저 정보를 조회
 		// 유저 정보에 ranking 프로퍼티를 추가 ( redis에서 조회한 ranking을 넣어줌)
 
-		const rankUsers: RankUserReturnDto[] = foundUsers.map((user) => ({
+		const rankUsers: RankUserReturnDto[] = foundUsers.map((user, index) => ({
 			...user,
-			ranking: Number(userRanking),
+			ranking: index + 1 + (page - 1) * 10,
 		}));
 		const totalItemCount = await this.userRepository.count(); // TODO: redis에 저장된 총 유저 수를 가져와야 하지 않을까?
 
 		return { rankUsers, totalItemCount };
 	}
+
+	@Cron(CronExpression.EVERY_10_MINUTES)
+	async handleCron() {
+		const users = await this.userRepository.find();
+		for (const user of users) {
+			Logger.log(`updateRanking: ${user.ladderScore}, ${user.id}`);
+			await this.AppService.updateRanking(user.ladderScore, user.id);
+		}
+	} 
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -161,7 +161,7 @@ export class UsersController {
 		summary: '유저 차단목록 조회',
 		description: 'pagination된 차단 유저 목록을 제공합니다.',
 	})
-	@ApiResponse({ status: 500, description: '쿼리에러' })
+	@ApiResponse({ status: 400, description: '쿼리에러' })
 	async findBlockListWithPage(
 		@GetUser() user: User,
 		@Query('page', ParseIntPipe, PositiveIntPipe) page: number,

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -13,9 +13,14 @@ import { RanksService } from './ranks.service';
 import { UsersController } from './users.controller';
 import { UsersRepository } from './users.repository';
 import { UsersService } from './users.service';
+import { ScheduleModule } from '@nestjs/schedule';
+import { AppService } from 'src/app.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([User, Friend, Block, Game])],
+	imports: [
+		TypeOrmModule.forFeature([User, Friend, Block, Game]),
+		ScheduleModule.forRoot(),
+	],
 	controllers: [UsersController],
 	providers: [
 		UsersService,
@@ -26,6 +31,7 @@ import { UsersService } from './users.service';
 		FriendsRepository,
 		BlocksRepository,
 		GameRepository,
+		AppService,
 	],
 	exports: [UsersService],
 })

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -72,29 +72,34 @@ export class UsersRepository extends Repository<User> {
 	}
 
 	async findRanksInfos(users: string[]) {
-		const rankUsers = await this.find({
-			select: ['nickname', 'avatar', 'ladderScore'],
-			where: {
-				id: In(users),
-			},
-		});
-		if (!rankUsers) {
-			throw new BadRequestException(
-				`there is no user with nickname ${users}`,
-			);
+		const rankUsers: User[] = [];
+		// Use forEach to iterate through users array
+		for (const userid of users) {
+			const user = await this.findOne({
+				select: [
+					'nickname',
+					'avatar',
+					'ladderScore',
+				],
+				where: { id: parseInt(userid) },
+			});
+			if (!user) {
+				throw new BadRequestException(`there is no user with id`);
+			}
+			rankUsers.push(user);
 		}
 		return rankUsers;
-	}
+	  }
 
 	async initAllSocketIdAndUserStatus() {
-		await this.update(
-			{},
-			{
-				status: UserStatus.OFFLINE,
-				channelSocketId: null,
+		await this.createQueryBuilder()
+			.update()
+			.set({
 				gameSocketId: null,
-			},
-		);
+				channelSocketId: null,
+				status: UserStatus.OFFLINE,
+			})
+			.execute();
 	}
 
 	// async findChannelSocketIdByUserId(userId: number) {


### PR DESCRIPTION
유저가 생성됨과 동시에 레디스에 initializing 헤줍니다.
- 'zadd' 사용시 score으로 정렬이 되도록 변경해주었습니다.

주기적으로(10분) 메인DB postgreSQL에서 유저를 가지고 와서 레디스에 업데이트 하는 작업을 합니다.
- NestJS에서 지원하는 크론잡으로 redis가 올라가있을때에는 업데이트가 가능하도록 수정해주었습니다.
ref : [https://docs.nestjs.com/techniques/task-scheduling](url)