### PR TITLE
feat(users): change '/ranks' without guards, pagination to chunked data

### DIFF
--- a/src/users/ranks.service.ts
+++ b/src/users/ranks.service.ts
@@ -14,17 +14,14 @@ export class RanksService {
 		@InjectRedis() private readonly redis: Redis,
 	) {}
 
-	async findRanksWithPage(page: number): Promise<RankUserResponseDto> {
+	async findRanksWithPage(): Promise<RankUserResponseDto> {
 		//userIDRanking: [userId, userId, userId, ...]
-		
 
 		const userRanking = await this.redis.zrevrange(
 			'rankings',
-			(page - 1) * 10,
-			page * 10 - 1,
+			0,
+			-1,
 		);
-
-		console.log('userranking', userRanking); // ok
 
 		const foundUsers = await this.userRepository.findRanksInfos(
 			userRanking,
@@ -37,7 +34,7 @@ export class RanksService {
 
 		const rankUsers: RankUserReturnDto[] = foundUsers.map((user, index) => ({
 			...user,
-			ranking: index + 1 + (page - 1) * 10,
+			ranking: index + 1
 		}));
 		const totalItemCount = await this.userRepository.count(); // TODO: redis에 저장된 총 유저 수를 가져와야 하지 않을까?
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -25,7 +25,6 @@ import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 @Controller('users')
 @ApiTags('users')
-@UseGuards(JwtAuthGuard)
 export class UsersController {
 	constructor(
 		private readonly usersService: UsersService,
@@ -35,7 +34,8 @@ export class UsersController {
 	) {}
 
 	private readonly logger = new Logger(UsersController.name);
-
+		
+	@UseGuards(JwtAuthGuard)
 	@Post('/friends')
 	@ApiOperation({
 		summary: '친구추가',
@@ -49,7 +49,8 @@ export class UsersController {
 		await this.friendsService.createFriend(user.id, toUserId);
 		// TODO: 친구요청을 받은 유저에게 알림 보내기
 	}
-
+	
+	@UseGuards(JwtAuthGuard)
 	@Delete('/friends')
 	@ApiOperation({
 		summary: '친구삭제',
@@ -62,7 +63,8 @@ export class UsersController {
 	) {
 		await this.friendsService.deleteFriend(user.id, toUserId);
 	}
-
+	
+	@UseGuards(JwtAuthGuard)
 	@Get('/friends')
 	@ApiOperation({
 		summary: '친구목록 조회',
@@ -79,7 +81,8 @@ export class UsersController {
 
 		return friendResponseDto;
 	}
-
+	
+	@UseGuards(JwtAuthGuard)
 	@Get('/me')
 	@ApiOperation({
 		summary: '내 정보 조회',
@@ -90,7 +93,8 @@ export class UsersController {
 
 		return myProfile;
 	}
-
+	
+	@UseGuards(JwtAuthGuard)
 	@Get('/profile/:nickname')
 	@ApiOperation({
 		summary: '유저 정보 조회',
@@ -108,7 +112,8 @@ export class UsersController {
 
 		return userProfile;
 	}
-
+	
+	@UseGuards(JwtAuthGuard)
 	@Get('/games/:nickname')
 	@ApiOperation({
 		summary: '게임 정보 조회',
@@ -128,7 +133,8 @@ export class UsersController {
 
 		return gameHistories;
 	}
-
+	
+	@UseGuards(JwtAuthGuard)
 	@Post('/blocks')
 	@ApiOperation({
 		summary: '유저 차단',
@@ -142,7 +148,8 @@ export class UsersController {
 	) {
 		await this.blocksService.applyBlock(user.id, toUserId);
 	}
-
+	
+	@UseGuards(JwtAuthGuard)
 	@Delete('/blocks')
 	@ApiOperation({
 		summary: '유저 차단 해제',
@@ -156,6 +163,7 @@ export class UsersController {
 		await this.blocksService.cancelBlock(user.id, toUserId);
 	}
 
+	@UseGuards(JwtAuthGuard)
 	@Get('/blocks')
 	@ApiOperation({
 		summary: '유저 차단목록 조회',
@@ -171,20 +179,19 @@ export class UsersController {
 
 		return BlockUserResponseDto;
 	}
-
+	
 	@Get('/rank')
 	@ApiOperation({
 		summary: '랭킹 조회',
 		description: '레디스로부터 pagination해 랭킹 목록을 제공합니다.',
 	})
-	async paging(@Query('page', ParseIntPipe, PositiveIntPipe) page: number) {
-		const rankResponseDto = await this.ranksServices.findRanksWithPage(
-			page,
-		);
+	async paging() {
+		const rankResponseDto = await this.ranksServices.findRanksWithPage();
 
 		return rankResponseDto;
 	}
-
+	
+	@UseGuards(JwtAuthGuard)
 	@Patch('/me/statusMessage')
 	@ApiOperation({
 		summary: '상태 메세지 변경',
@@ -211,7 +218,8 @@ export class UsersController {
 
 		await this.usersService.updateMyStatusMessage(user.id, statusMessage);
 	}
-
+	
+	@UseGuards(JwtAuthGuard)
 	@Patch('/me/avatar')
 	@ApiOperation({
 		summary: '아바타 변경',


### PR DESCRIPTION
- 기존의 랭크 pagination 에서 랭킹API 가 너무많이 호출되는 우려되는 상황으로 인해, 전체의 랭크데이터를 불러오는 것으로 변경했습니다.
- 또한, ranking 데이터를 외부에서 확인할 수 있도록 수정해주었습니다.
- user.controller의 '/ranks'를  userGuards를 제외하여 토큰인증없이도 랭킹데이터를 조회 가능하도록 변경했습니다.