### PR TITLE
feat: socket.io cors errror solving

### DIFF
--- a/src/socket-adapter/socket-io.adapter.ts
+++ b/src/socket-adapter/socket-io.adapter.ts
@@ -1,7 +1,7 @@
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { INestApplicationContext } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { Server, Socket } from 'socket.io';
+import { Server, Socket, ServerOptions } from 'socket.io';
 import { WSUnauthorizedException } from '../common/exception/custom-exception';
 import { UsersRepository } from '../users/users.repository';
 import { User } from '../users/entities/user.entity';
@@ -22,8 +22,23 @@ export class SocketIoAdapter extends IoAdapter {
 		const jwtService = this.app.get(JwtService);
 		const configService = this.app.get(ConfigService);
 		const userRepository = this.app.get(UsersRepository);
+		const clientPort = '8001';
 
-		const server: Server = super.createIOServer(port, options);
+		const cors = {
+			origin: [
+				`http://localhost:${clientPort}`,
+				new RegExp(
+					`/^http:\/\/192\.168\.1\.([1-9]|[1-9]\d):${clientPort}$/`,
+				),
+			],
+		};
+
+		const optionsWithCORS: ServerOptions = {
+			...options,
+			cors,
+		};
+
+		const server: Server = super.createIOServer(port, optionsWithCORS);
 
 		const namespaces = ['channels'];
 

--- a/src/socket-adapter/socket-io.adapter.ts
+++ b/src/socket-adapter/socket-io.adapter.ts
@@ -25,6 +25,7 @@ export class SocketIoAdapter extends IoAdapter {
 		const clientPort = '8001';
 
 		const cors = {
+			credentials: true,
 			origin: [
 				`http://localhost:${clientPort}`,
 				new RegExp(


### PR DESCRIPTION
- 클라이언트가 websocket 연결 요청시 cors error 나는 문제
  - 첫 http handshake시에 문제가 생기는 것 같은데, .enableCors로 해결이 안됩니다.
  - 저번에 만들었던 SocketIoAdapter에서 서버를 만들 때, cors 옵션을 줘봤습니다.
  - 일단 되는지 확인 예정!