### PR TITLE
fix: channel gateway, game gateway 수정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -13,7 +13,7 @@ import { Response } from 'express';
 import { User } from 'src/users/entities/user.entity';
 import { SignupRequestDto } from '../users/dto/signup-request.dto';
 import { UsersService } from '../users/users.service';
-import { AppService } from './../app.service';
+import { AppService } from '../app.service';
 import { AuthService } from './auth.service';
 import { UserSigninResponseDto } from './dto/user-signin-response.dto';
 import { FtAuthService } from './ft-auth.service';

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -52,7 +52,6 @@ import { JwtRefreshStrategy } from './jwt-refresh.strategy';
 		GameInvitationRepository,
 		FriendsRepository,
 		BlocksRepository,
-		ChannelsGateway,
 		ChannelUsersRepository,
 		FriendsRepository,
 		AppService,

--- a/src/channels/channels.module.ts
+++ b/src/channels/channels.module.ts
@@ -52,5 +52,6 @@ import { Channel } from './entities/channel.entity';
 		FriendsRepository,
 		BlocksRepository,
 	],
+	exports: [ChannelsGateway],
 })
 export class ChannelsModule {}

--- a/src/game/dto/create-game-param.dto.ts
+++ b/src/game/dto/create-game-param.dto.ts
@@ -1,0 +1,4 @@
+export class CreateGameParamDto {
+	invitedUserId: number;
+	invitationId: number;
+}

--- a/src/game/dto/gateway-join-room-param.dto.ts
+++ b/src/game/dto/gateway-join-room-param.dto.ts
@@ -1,0 +1,5 @@
+export class GatewayJoinRoomParamDto {
+	invitingUserId: number;
+	invitedUserId: number;
+	roomName: string;
+}

--- a/src/game/game-invitation.repository.ts
+++ b/src/game/game-invitation.repository.ts
@@ -1,11 +1,33 @@
 import { DataSource, Repository } from 'typeorm';
 import { GameInvitation } from './entities/game-invitation.entity';
 import { InjectRepository } from '@nestjs/typeorm';
+import { CreateGameInvitationParamDto } from './dto/create-invitation-param.dto';
+import { DBUpdateFailureException } from '../common/exception/custom-exception';
 
 export class GameInvitationRepository extends Repository<GameInvitation> {
 	constructor(
 		@InjectRepository(GameInvitation) private dataSource: DataSource,
 	) {
 		super(GameInvitation, dataSource.manager);
+	}
+
+	async createGameInvitation(
+		gameInvitationDto: CreateGameInvitationParamDto,
+	) {
+		const gameInvitation = this.create({
+			invitingUserId: gameInvitationDto.invitingUser.id,
+			invitedUserId: gameInvitationDto.invitedUserId,
+			gameType: gameInvitationDto.gameType,
+		});
+		const result = await this.save(gameInvitation);
+		if (!result)
+			throw DBUpdateFailureException('create game invitation failed');
+		return result;
+	}
+
+	async deleteGameInvitaiton(invitationId: number) {
+		const result = await this.softDelete(invitationId);
+		if (result.affected !== 1)
+			throw DBUpdateFailureException('delete user from channel failed');
 	}
 }

--- a/src/game/game.controller.ts
+++ b/src/game/game.controller.ts
@@ -1,11 +1,20 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
-import { ApiTags } from '@nestjs/swagger';
+import {
+	Body,
+	Controller,
+	Delete,
+	ParseIntPipe,
+	Post,
+	UseGuards,
+} from '@nestjs/common';
+import { GameService } from './game.service';
+import { CreateInvitationRequestDto } from './dto/create-invitation-request.dto';
 import { GetUser } from '../auth/get-user.decorator';
 import { User } from '../users/entities/user.entity';
+import { ApiTags } from '@nestjs/swagger';
 import { CreateGameInvitationParamDto } from './dto/create-invitation-param.dto';
-import { CreateInvitationRequestDto } from './dto/create-invitation-request.dto';
-import { GameService } from './game.service';
+import { PositiveIntPipe } from '../common/pipes/positiveInt.pipe';
+import { CreateGameParamDto } from './dto/create-game-param.dto';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('game')
 @ApiTags('game')
@@ -27,5 +36,35 @@ export class GameController {
 		await this.gameService.createInvitation(invitationParamDto);
 	}
 
-	// @Post('/accept')
+	/**
+	 * 초대 수락
+	 * @param user
+	 * @param invitationId 초대 테이블의 id
+	 * (초대시 프론트가 이벤트를 수신하며 받은 data 입니다)
+	 */
+	@Post('/accept')
+	async createGame(
+		@GetUser() user: User,
+		@Body('invitationId', ParseIntPipe, PositiveIntPipe)
+		invitationId: number,
+	) {
+		const createGameParamDto: CreateGameParamDto = {
+			invitedUserId: user.id,
+			invitationId: invitationId,
+		};
+		await this.gameService.createGame(createGameParamDto);
+	}
+
+	@Delete('/reject')
+	async deleteInvitation(
+		@GetUser() user: User,
+		@Body('invitationId', ParseIntPipe, PositiveIntPipe)
+		invitationId: number,
+	) {
+		const deleteInvitationParamDto: CreateGameParamDto = {
+			invitedUserId: user.id,
+			invitationId: invitationId,
+		};
+		await this.gameService.deleteInvitation(deleteInvitationParamDto);
+	}
 }

--- a/src/game/game.module.ts
+++ b/src/game/game.module.ts
@@ -11,15 +11,31 @@ import { GameInvitation } from './entities/game-invitation.entity';
 import { GameGateway } from './game.gateway';
 import { AuthService } from '../auth/auth.service';
 import { JwtService } from '@nestjs/jwt';
+import { ChannelUsersRepository } from '../channels/channel-users.repository';
+import { FriendsRepository } from '../users/friends.repository';
+import { ChannelUser } from '../channels/entities/channel-user.entity';
+import { Friend } from '../users/entities/friend.entity';
+import { ChannelsModule } from '../channels/channels.module';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Game, GameInvitation, User])],
+	imports: [
+		TypeOrmModule.forFeature([
+			Game,
+			GameInvitation,
+			User,
+			ChannelUser,
+			Friend,
+		]),
+		ChannelsModule,
+	],
 	controllers: [GameController],
 	providers: [
 		GameGateway,
 		GameService,
 		AuthService,
 		JwtService,
+		ChannelUsersRepository,
+		FriendsRepository,
 		GameRepository,
 		GameInvitationRepository,
 		UsersRepository,

--- a/src/game/game.repository.ts
+++ b/src/game/game.repository.ts
@@ -2,14 +2,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { GAME_DEFAULT_PAGE_SIZE } from 'src/common/constants';
 import { DataSource, Repository } from 'typeorm';
 import { Game } from './entities/game.entity';
-import { CreateGameInvitationParamDto } from './dto/create-invitation-param.dto';
-import { DBUpdateFailureException } from '../common/exception/custom-exception';
-import { GameInvitationRepository } from './game-invitation.repository';
 export class GameRepository extends Repository<Game> {
-	constructor(
-		@InjectRepository(Game) private dataSource: DataSource,
-		private readonly gameInvitationRepository: GameInvitationRepository,
-	) {
+	constructor(@InjectRepository(Game) private dataSource: DataSource) {
 		super(Game, dataSource.manager);
 	}
 
@@ -43,19 +37,5 @@ export class GameRepository extends Repository<Game> {
 			],
 		);
 		return gameHistories;
-	}
-
-	async createGameInvitation(
-		gameInvitationDto: CreateGameInvitationParamDto,
-	) {
-		const gameInvitation = this.gameInvitationRepository.create({
-			invitingUserId: gameInvitationDto.invitingUser.id,
-			invitedUserId: gameInvitationDto.invitedUserId,
-			gameType: gameInvitationDto.gameType,
-		});
-		const result = await this.gameInvitationRepository.save(gameInvitation);
-		if (!result)
-			throw DBUpdateFailureException('create game invitation failed');
-		return result;
 	}
 }


### PR DESCRIPTION
- 현재 코드 상에서는 game invite를 받기 위해 game socket을 연결시켜야합니다. 
  하지만 invitation은 ONLINE이기만 해도 받을 수 있어야한다고 생각하며, game socket의 연결 시점은 game이 확정된 이후여야 한다고 생각합니다 !
  **그래서 GameGateway의 inviteGame을 ChannelsGateway로 옮겼습니다. .** 

- ChannelsGateway가 싱글톤 패턴으로 생성되지 않는 문제가 있었습니다! AuthModule과 ChannelsModule 두곳의 providers 배열에 포함되어 있던 ChannelsGateway가(AuthModule에서는 gateway를 갖다쓰려다가 만 것 같습니다) 두개의 인스턴스가 되어 연결 요청과 메세지 수신을 동시에 받고있었던 것입니다.
  
  우리는 @Injectable @Module (+ @WebSocketGateway) 데코레이터가 싱글톤 패턴을 무조건 보장한다고 알고있었습니다. 하지만 ! 각기 다른 모듈의 providers에 중복되어 포함되는 클래스들은 싱글톤이 보장되지 않더군요 !  !
  **그래서 ChannelsGateway를 export하고, ChannelsGateway를 쓰는 다른 모듈에서는 ChannelsModule을 import 해주었습니다.**
  추후 모듈 정리도 하고싶군요.

- GameGateway disconnect 예외처리시 잘못된 조건문때문에 user의 gameSocketId가 지워지지 않고 있었습니다. 조건문을 수정해주었습니다.

- 게임 초대 수락 로직 진행중
  