### PR TITLE
fix: 게임 초대하기 취소, 수락 및 거절 로직

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"class-validator": "^0.14.0",
 				"cookie-parser": "^1.4.6",
 				"ioredis": "^5.3.2",
+				"moment": "^2.29.4",
 				"passport-jwt": "^4.0.1",
 				"pg": "^8.11.3",
 				"reflect-metadata": "^0.1.13",
@@ -7197,6 +7198,14 @@
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/moment": {
+			"version": "2.29.4",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"class-validator": "^0.14.0",
 		"cookie-parser": "^1.4.6",
 		"ioredis": "^5.3.2",
+		"moment": "^2.29.4",
 		"passport-jwt": "^4.0.1",
 		"pg": "^8.11.3",
 		"reflect-metadata": "^0.1.13",

--- a/src/common/events.ts
+++ b/src/common/events.ts
@@ -3,3 +3,5 @@
 export const EVENT_USER_STATUS = 'userStatus'; // 유저의 상태 변경 이벤트
 
 export const EVENT_GAME_INVITATION = 'gameInvitation';
+
+export const EVENT_GAME_INVITATION_REPLY = 'gameInvitationReply';

--- a/src/game/dto/create-game-param.dto.ts
+++ b/src/game/dto/create-game-param.dto.ts
@@ -1,4 +1,4 @@
 export class CreateGameParamDto {
+	gameInvitationId: number;
 	invitedUserId: number;
-	invitationId: number;
 }

--- a/src/game/dto/create-game-param.dto.ts
+++ b/src/game/dto/create-game-param.dto.ts
@@ -1,4 +1,4 @@
 export class CreateGameParamDto {
-	gameInvitationId: number;
+	invitationId: number;
 	invitedUserId: number;
 }

--- a/src/game/dto/create-invitation-request.dto.ts
+++ b/src/game/dto/create-invitation-request.dto.ts
@@ -2,7 +2,7 @@ import { GameType } from '../../common/enum';
 import { IsIn, IsInt, IsPositive, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class CreateInvitationRequestDto {
+export class CreateGameInvitationRequestDto {
 	@ApiProperty({ description: '초대한 유저id' })
 	@IsInt()
 	@IsPositive()

--- a/src/game/dto/delete-invitation-param.dto.ts
+++ b/src/game/dto/delete-invitation-param.dto.ts
@@ -1,0 +1,4 @@
+export class DeleteGameInvitationParamDto {
+	cancelingUserId: number;
+	gameInvitationId: number;
+}

--- a/src/game/dto/delete-invitation-param.dto.ts
+++ b/src/game/dto/delete-invitation-param.dto.ts
@@ -1,4 +1,4 @@
 export class DeleteGameInvitationParamDto {
 	cancelingUserId: number;
-	gameInvitationId: number;
+	invitationId: number;
 }

--- a/src/game/dto/delete-invitations-param.dto.ts
+++ b/src/game/dto/delete-invitations-param.dto.ts
@@ -1,0 +1,4 @@
+export class DeleteGameInvitationsParamDto {
+	invitingUserId: number;
+	invitedUserId: number;
+}

--- a/src/game/dto/game-param.dto.ts
+++ b/src/game/dto/game-param.dto.ts
@@ -1,0 +1,37 @@
+import { GameStatus, GameType } from '../../common/enum';
+
+export class GameParamDto {
+	winnerId: number;
+	loserId: number;
+	gameType: GameType;
+	winnerScore: number;
+	loserScore: number;
+	gameStatus: GameStatus;
+	ballSpeed: number;
+	racketSize: number;
+
+	constructor(player1Id: number, player2Id: number, gameType: GameType) {
+		this.winnerId = player1Id;
+		this.loserId = player2Id;
+		this.gameType = gameType;
+		this.winnerScore = 0;
+		this.loserScore = 0;
+		this.gameStatus = GameStatus.WAITING;
+		if (
+			this.gameType === GameType.SPECIAL_INVITE ||
+			this.gameType === GameType.SPECIAL_MATCHING
+		) {
+			this.ballSpeed = this.getRandomNumber(1, 3);
+			this.racketSize = this.getRandomNumber(1, 3);
+		} else {
+			// Set to 1 for NORMAL
+			this.ballSpeed = 1;
+			this.racketSize = 1;
+		}
+	}
+
+	private getRandomNumber(min: number, max: number): number {
+		// Generate a random integer between min and max (inclusive)
+		return Math.floor(Math.random() * (max - min + 1)) + min;
+	}
+}

--- a/src/game/dto/gateway-create-invitation-param.dto.ts
+++ b/src/game/dto/gateway-create-invitation-param.dto.ts
@@ -1,12 +1,12 @@
 import { IsIn, IsString } from 'class-validator';
 import { GameType } from '../../common/enum';
 
-export class GatewayCreateInvitationParamDto {
+export class GatewayCreateGameInvitationParamDto {
 	invitationId: number;
 
 	invitingUserNickname: string;
 
-	invitedUserId: number;
+	invitedUserChannelSocketId: string;
 
 	@IsIn([GameType.NORMAL_INVITE, GameType.SPECIAL_INVITE])
 	@IsString()

--- a/src/game/dto/gateway-join-game-room-param.dto.ts
+++ b/src/game/dto/gateway-join-game-room-param.dto.ts
@@ -1,4 +1,4 @@
-export class GatewayJoinRoomParamDto {
+export class GatewayJoinGameRoomParamDto {
 	invitingUserId: number;
 	invitedUserId: number;
 	roomName: string;

--- a/src/game/dto/gateway-send-invitation-reaponse.dto.ts
+++ b/src/game/dto/gateway-send-invitation-reaponse.dto.ts
@@ -1,0 +1,5 @@
+export class GatewaySendInvitationReplyDto {
+	targetUserChannelSocketId: string;
+	isAccepted: boolean;
+	gameId: number | null;
+}

--- a/src/game/game-invitation.repository.ts
+++ b/src/game/game-invitation.repository.ts
@@ -3,6 +3,7 @@ import { GameInvitation } from './entities/game-invitation.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateGameInvitationParamDto } from './dto/create-invitation-param.dto';
 import { DBUpdateFailureException } from '../common/exception/custom-exception';
+import { DeleteGameInvitationsParamDto } from './dto/delete-invitations-param.dto';
 
 export class GameInvitationRepository extends Repository<GameInvitation> {
 	constructor(
@@ -19,15 +20,36 @@ export class GameInvitationRepository extends Repository<GameInvitation> {
 			invitedUserId: gameInvitationDto.invitedUserId,
 			gameType: gameInvitationDto.gameType,
 		});
+
 		const result = await this.save(gameInvitation);
+
 		if (!result)
 			throw DBUpdateFailureException('create game invitation failed');
+
 		return result;
 	}
 
-	async deleteGameInvitaiton(invitationId: number) {
-		const result = await this.softDelete(invitationId);
-		if (result.affected !== 1)
-			throw DBUpdateFailureException('delete user from channel failed');
+	async deleteGameInvitaitons(
+		deleteInvitationsDto: DeleteGameInvitationsParamDto,
+	) {
+		const invitingUserId = deleteInvitationsDto.invitingUserId;
+		const invitedUserId = deleteInvitationsDto.invitedUserId;
+
+		const result = await this.dataSource.query(
+			`
+			UPDATE game_invitation
+			SET "deletedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+			WHERE "invitingUserId" = $1
+			AND "invitedUserId" = $2
+			AND "deletedAt" IS NULL
+			`,
+			[invitingUserId, invitedUserId],
+		);
+		// 	AND now() - "createdAt" >= INTERVAL '10 seconds'
+
+		if (result[1] === 0)
+			throw DBUpdateFailureException(
+				'soft delete game invitations failed',
+			);
 	}
 }

--- a/src/game/game.controller.ts
+++ b/src/game/game.controller.ts
@@ -42,18 +42,18 @@ export class GameController {
 	/**
 	 * 초대 수락
 	 * @param user
-	 * @param gameInvitationId 초대 테이블의 id
+	 * @param invitationId 초대 테이블의 id
 	 * (초대시 프론트가 이벤트를 수신하며 받은 data 입니다)
 	 */
 	@Post('/accept')
 	async createGame(
 		@GetUser() user: User,
 		@Body('gameInvitationId', ParseIntPipe, PositiveIntPipe)
-		gameInvitationId: number,
+		invitationId: number,
 	) {
 		const createGameParamDto: CreateGameParamDto = {
 			invitedUserId: user.id,
-			gameInvitationId: gameInvitationId,
+			invitationId: invitationId,
 		};
 		await this.gameService.createGame(createGameParamDto);
 	}
@@ -62,11 +62,11 @@ export class GameController {
 	async deleteInvitation(
 		@GetUser() user: User,
 		@Param('gameInvitationId', ParseIntPipe, PositiveIntPipe)
-		gameInvitationId: number,
+		invitationId: number,
 	) {
 		const deleteInvitationParamDto: DeleteGameInvitationParamDto = {
 			cancelingUserId: user.id,
-			gameInvitationId: gameInvitationId,
+			invitationId: invitationId,
 		};
 		await this.gameService.deleteInvitationByInvitingUserId(
 			deleteInvitationParamDto,
@@ -77,11 +77,11 @@ export class GameController {
 	async refuseInvitation(
 		@GetUser() user: User,
 		@Param('gameInvitationId', ParseIntPipe, PositiveIntPipe)
-		gameInvitationId: number,
+		invitationId: number,
 	) {
 		const deleteInvitationParamDto: DeleteGameInvitationParamDto = {
 			cancelingUserId: user.id,
-			gameInvitationId: gameInvitationId,
+			invitationId: invitationId,
 		};
 		await this.gameService.deleteInvitationByInvitedUserId(
 			deleteInvitationParamDto,

--- a/src/game/game.module.ts
+++ b/src/game/game.module.ts
@@ -16,6 +16,8 @@ import { FriendsRepository } from '../users/friends.repository';
 import { ChannelUser } from '../channels/entities/channel-user.entity';
 import { Friend } from '../users/entities/friend.entity';
 import { ChannelsModule } from '../channels/channels.module';
+import { Block } from '../users/entities/block.entity';
+import { BlocksRepository } from '../users/blocks.repository';
 
 @Module({
 	imports: [
@@ -25,6 +27,7 @@ import { ChannelsModule } from '../channels/channels.module';
 			User,
 			ChannelUser,
 			Friend,
+			Block,
 		]),
 		ChannelsModule,
 	],
@@ -36,6 +39,7 @@ import { ChannelsModule } from '../channels/channels.module';
 		JwtService,
 		ChannelUsersRepository,
 		FriendsRepository,
+		BlocksRepository,
 		GameRepository,
 		GameInvitationRepository,
 		UsersRepository,

--- a/src/game/game.repository.ts
+++ b/src/game/game.repository.ts
@@ -2,9 +2,23 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { GAME_DEFAULT_PAGE_SIZE } from 'src/common/constants';
 import { DataSource, Repository } from 'typeorm';
 import { Game } from './entities/game.entity';
+import { CreateGameInvitationParamDto } from './dto/create-invitation-param.dto';
+import { DBUpdateFailureException } from '../common/exception/custom-exception';
+import { GameParamDto } from './dto/game-param.dto';
 export class GameRepository extends Repository<Game> {
 	constructor(@InjectRepository(Game) private dataSource: DataSource) {
 		super(Game, dataSource.manager);
+	}
+
+	async createGame(gameParamDto: GameParamDto) {
+		const game = this.create(gameParamDto);
+
+		const result = await this.save(game);
+
+		if (!result)
+			throw DBUpdateFailureException('create game invitation failed');
+
+		return result;
 	}
 
 	async findGameHistoriesWithPage(userId: number, page: number) {

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -6,11 +6,17 @@ import {
 import { GameRepository } from './game.repository';
 import { UsersRepository } from '../users/users.repository';
 import { CreateGameInvitationParamDto } from './dto/create-invitation-param.dto';
-import { GatewayCreateInvitationParamDto } from './dto/gateway-create-invitation-param.dto';
+import { GatewayCreateGameInvitationParamDto } from './dto/gateway-create-invitation-param.dto';
 import { GameGateway } from './game.gateway';
-import { CreateGameParamDto } from './dto/create-game-param.dto';
+import { GameParamDto } from './dto/game-param.dto';
 import { GameInvitationRepository } from './game-invitation.repository';
-import { ChannelsGateway } from '../channels/channels.gateway';
+import { DeleteGameInvitationParamDto } from './dto/delete-invitation-param.dto';
+import { DeleteGameInvitationsParamDto } from './dto/delete-invitations-param.dto';
+import { UserStatus } from '../common/enum';
+import { CreateGameParamDto } from './dto/create-game-param.dto';
+import { GatewaySendInvitationReplyDto } from './dto/gateway-send-invitation-reaponse.dto';
+import { User } from '../users/entities/user.entity';
+import * as moment from 'moment';
 
 @Injectable()
 export class GameService {
@@ -18,48 +24,48 @@ export class GameService {
 		private readonly gameRepository: GameRepository,
 		private readonly gameInvitationRepository: GameInvitationRepository,
 		private readonly gameGateway: GameGateway,
-		private readonly channelsGateway: ChannelsGateway,
 		private readonly usersRepository: UsersRepository,
 	) {}
 
 	async createInvitation(invitationParamDto: CreateGameInvitationParamDto) {
 		const invitingUser = invitationParamDto.invitingUser;
 		const invitedUserId = invitationParamDto.invitedUserId;
+		const gameType = invitationParamDto.gameType;
 
 		// 본인 스스로인지
-		if (invitingUser.id == invitedUserId)
-			throw new BadRequestException(`could not invite yourself`);
+		if (invitingUser.id === invitedUserId)
+			throw new BadRequestException('자기 자신을 초대할 수 없습니다');
 
 		// 상대가 존재하는 유저인지
-		const invitedUser = await this.usersRepository.findOne({
-			where: {
-				id: invitedUserId,
-			},
-		});
-		if (!invitedUser) {
-			throw new BadRequestException(
-				`user ${invitedUserId} does not exist`,
-			);
-		}
+		const invitedUser = await this.checkUserExist(invitedUserId);
 
-		// Game Invitation DB 저장
+		// 상대가 ONLINE 인지 => 접속 중인 유저가 아니라면 없던 일이 됨
+		if (
+			invitedUser.status === UserStatus.OFFLINE ||
+			!invitedUser.channelSocketId
+		)
+			throw new ImATeapotException(
+				`초대된 유저 ${invitedUserId} 는 OFFLINE 상태입니다`,
+			);
+
+		// game invitation DB 저장
 		const gameInvitation =
 			await this.gameInvitationRepository.createGameInvitation(
 				invitationParamDto,
 			);
 
 		// TODO: 알림 보내기
-		const gatewayInvitationParamDto: GatewayCreateInvitationParamDto = {
+		const gatewayInvitationParamDto: GatewayCreateGameInvitationParamDto = {
 			invitationId: gameInvitation.id,
 			invitingUserNickname: invitingUser.nickname,
-			invitedUserId: invitedUserId,
-			gameType: invitationParamDto.gameType,
+			invitedUserChannelSocketId: invitedUser.channelSocketId,
+			gameType: gameType,
 		};
-		await this.channelsGateway.inviteGame(gatewayInvitationParamDto);
+		await this.gameGateway.inviteGame(gatewayInvitationParamDto);
 	}
 
 	async createGame(createGameParamDto: CreateGameParamDto) {
-		const invitationId = createGameParamDto.invitationId;
+		const invitationId = createGameParamDto.gameInvitationId;
 		const invitedUserId = createGameParamDto.invitedUserId;
 
 		const invitation = await this.gameInvitationRepository.findOne({
@@ -67,17 +73,124 @@ export class GameService {
 				id: invitationId,
 				invitedUserId: invitedUserId,
 			},
+			order: { createdAt: 'DESC' },
 		});
 		if (!invitation)
-			return new ImATeapotException(
-				`invitation id ${invitationId}는 존재하지 않습니다`,
+			throw new ImATeapotException(
+				`해당하는 invitation id ${invitationId} 가 없습니다`,
 			);
-		// Game setting
+
+		// 10초 지나면 유효하지 않은 초대
+		const currentTime = moment();
+		const diff = currentTime.diff(invitation.createdAt, 'seconds');
+
+		if (diff >= 10) {
+			throw new ImATeapotException(
+				`해당하는 invitation id ${invitationId} 는 시간초과로 유효하지 않습니다`,
+			);
+		}
+
+		// 두 유저 모두 ONLINE 인지 확인
+		const invitingUser = await this.checkUserExist(
+			invitation.invitingUserId,
+		);
+		if (
+			invitingUser.status === UserStatus.OFFLINE ||
+			!invitingUser.channelSocketId
+		)
+			throw new ImATeapotException(
+				`초대한 유저 ${invitingUser.id} 는 OFFLINE 상태입니다`,
+			);
+
+		const invitedUser = await this.checkUserExist(invitedUserId);
+
+		if (
+			invitedUser.status === UserStatus.OFFLINE ||
+			!invitedUser.channelSocketId
+		)
+			throw new ImATeapotException(
+				`초대된 유저 ${invitedUser.id} 는 OFFLINE 상태입니다`,
+			);
+
+		/* TODO: DB에 쌓인 유효하지 않은 초대장들은 어떻게 지우지 ?
+		 *	1. cache-manager ttl을 쓴다
+		 *	2. cron을 쓴다
+		 * 	3. 그냥 놔둔다
+		 * 	4. 트리거가 되는 요청 때 기회는 이때다! 지워버린다
+		 *	일단 4가 채택됨 -> 취소 및 거절시 해당하는 invitation이 있을 때 */
+
+		/* TODO: Game 세팅
+		 *	1. game DB 만들기 ✅
+		 *
+		 * 	2. game room join하기
+		 * 	3. game start event emit */
+
+		const plyer1Id = invitingUser.id;
+		const plyer2Id = invitedUser.id;
+		const gameType = invitation.gameType;
+
+		const gameParamDto = new GameParamDto(plyer1Id, plyer2Id, gameType);
+		const game = await this.gameRepository.createGame(gameParamDto);
+
+		// 성사됐으니까 game invitation 지워주기
+		await this.gameInvitationRepository.softDelete({
+			id: invitationId,
+		});
+
+		// 두 유저에게 game id emit
+		const invitationReplyToInvitingUserDto: GatewaySendInvitationReplyDto =
+			{
+				targetUserChannelSocketId: invitingUser.channelSocketId,
+				isAccepted: true,
+				gameId: game.id,
+			};
+		const invitationReplyToInvitedUserDto: GatewaySendInvitationReplyDto = {
+			targetUserChannelSocketId: invitedUser.channelSocketId,
+			isAccepted: true,
+			gameId: game.id,
+		};
+
+		await this.gameGateway.sendInvitationReply(
+			invitationReplyToInvitingUserDto,
+		);
+		await this.gameGateway.sendInvitationReply(
+			invitationReplyToInvitedUserDto,
+		);
 	}
 
-	async deleteInvitation(deleteInvitationParamDto: CreateGameParamDto) {
-		const invitationId = deleteInvitationParamDto.invitationId;
-		const invitedUserId = deleteInvitationParamDto.invitedUserId;
+	async deleteInvitationByInvitingUserId(
+		deleteInvitationParamDto: DeleteGameInvitationParamDto,
+	) {
+		const invitationId = deleteInvitationParamDto.gameInvitationId;
+		const invitingUserId = deleteInvitationParamDto.cancelingUserId;
+
+		const invitation = await this.gameInvitationRepository.findOne({
+			where: {
+				id: invitationId,
+				invitingUserId: invitingUserId,
+			},
+		});
+		if (!invitation)
+			throw new ImATeapotException(
+				`해당하는 invitation id ${invitationId} 가 없습니다`,
+			);
+
+		// 초대 보낸 사람, 받은 사람 일치하는 초대 쌓인거 모두 삭제
+		const deleteInvitationsDto: DeleteGameInvitationsParamDto = {
+			invitingUserId: invitation.invitingUserId,
+			invitedUserId: invitation.invitedUserId,
+		};
+
+		await this.gameInvitationRepository.deleteGameInvitaitons(
+			deleteInvitationsDto,
+		);
+	}
+
+	async deleteInvitationByInvitedUserId(
+		deleteInvitationParamDto: DeleteGameInvitationParamDto,
+	) {
+		const invitationId = deleteInvitationParamDto.gameInvitationId;
+		const invitedUserId = deleteInvitationParamDto.cancelingUserId;
 
 		const invitation = await this.gameInvitationRepository.findOne({
 			where: {
@@ -86,11 +199,50 @@ export class GameService {
 			},
 		});
 		if (!invitation)
-			return new ImATeapotException(
-				`invitation id ${invitationId}는 존재하지 않습니다`,
+			throw new ImATeapotException(
+				`해당하는 invitation id ${invitationId} 가 없습니다`,
 			);
 
-		// invitation DB 지우기
-		await this.gameInvitationRepository.deleteGameInvitaiton(invitationId);
+		// 초대 보낸 사람, 받은 사람 일치하는 초대 쌓인거 모두 삭제
+		const deleteInvitationsDto: DeleteGameInvitationsParamDto = {
+			invitingUserId: invitation.invitingUserId,
+			invitedUserId: invitation.invitedUserId,
+		};
+
+		await this.gameInvitationRepository.deleteGameInvitaitons(
+			deleteInvitationsDto,
+		);
+
+		// 초대 보낸 사람에게 초대가 거절됨을 알려야함
+		// 초대 보낸 사람이 ONLINE 인지 확인
+		const invitingUser = await this.checkUserExist(
+			invitation.invitingUserId,
+		);
+		if (
+			invitingUser.status === UserStatus.OFFLINE ||
+			!invitingUser.channelSocketId
+		)
+			throw new ImATeapotException(
+				`초대한 유저 ${invitingUser.id} 는 OFFLINE 상태입니다`,
+			);
+
+		const sendInvitationReplyDto: GatewaySendInvitationReplyDto = {
+			targetUserChannelSocketId: invitingUser.channelSocketId,
+			isAccepted: false,
+			gameId: null,
+		};
+
+		await this.gameGateway.sendInvitationReply(sendInvitationReplyDto);
+	}
+
+	private async checkUserExist(userId: number): Promise<User> {
+		const user = await this.usersRepository.findOne({
+			where: { id: userId },
+		});
+
+		if (!user) {
+			throw new BadRequestException(`user ${userId} does not exist`);
+		}
+		return user as User;
 	}
 }

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -17,6 +17,7 @@ import { CreateGameParamDto } from './dto/create-game-param.dto';
 import { GatewaySendInvitationReplyDto } from './dto/gateway-send-invitation-reaponse.dto';
 import { User } from '../users/entities/user.entity';
 import * as moment from 'moment';
+import { BlocksRepository } from '../users/blocks.repository';
 
 @Injectable()
 export class GameService {
@@ -25,6 +26,7 @@ export class GameService {
 		private readonly gameInvitationRepository: GameInvitationRepository,
 		private readonly gameGateway: GameGateway,
 		private readonly usersRepository: UsersRepository,
+		private readonly blocksRepository: BlocksRepository,
 	) {}
 
 	async createInvitation(invitationParamDto: CreateGameInvitationParamDto) {
@@ -47,6 +49,10 @@ export class GameService {
 			throw new ImATeapotException(
 				`초대된 유저 ${invitedUserId} 는 OFFLINE 상태입니다`,
 			);
+		const isblocked = await this.blocksRepository.findOne({
+			where: { fromUserId: invitedUserId, toUserId: invitingUser.id },
+		});
+		if (isblocked) return;
 
 		// game invitation DB 저장
 		const gameInvitation =
@@ -65,7 +71,7 @@ export class GameService {
 	}
 
 	async createGame(createGameParamDto: CreateGameParamDto) {
-		const invitationId = createGameParamDto.gameInvitationId;
+		const invitationId = createGameParamDto.invitationId;
 		const invitedUserId = createGameParamDto.invitedUserId;
 
 		const invitation = await this.gameInvitationRepository.findOne({
@@ -161,7 +167,7 @@ export class GameService {
 	async deleteInvitationByInvitingUserId(
 		deleteInvitationParamDto: DeleteGameInvitationParamDto,
 	) {
-		const invitationId = deleteInvitationParamDto.gameInvitationId;
+		const invitationId = deleteInvitationParamDto.invitationId;
 		const invitingUserId = deleteInvitationParamDto.cancelingUserId;
 
 		const invitation = await this.gameInvitationRepository.findOne({
@@ -189,7 +195,7 @@ export class GameService {
 	async deleteInvitationByInvitedUserId(
 		deleteInvitationParamDto: DeleteGameInvitationParamDto,
 	) {
-		const invitationId = deleteInvitationParamDto.gameInvitationId;
+		const invitationId = deleteInvitationParamDto.invitationId;
 		const invitedUserId = deleteInvitationParamDto.cancelingUserId;
 
 		const invitation = await this.gameInvitationRepository.findOne({


### PR DESCRIPTION
- 게임 초대를 취소하는 api 

- 게임 초대를 수락하는 api
  - 게임을 생성하고 초대 보낸 사람과 받은 사람 모두에게 gameInvitationReply 이벤트를 보냅니다

- 게임 초대를 거절하는 api
    - 초대 보낸 사람에게 gameInvitationReply 이벤트를 보냅니다
 
- inviteGame 등 ChannelsGateway의 서버 소켓이 필요한 메서드들의 경우,
 GameGateway에서 ChannelsGateway를 주입 받아 ChannelsGateway의 server에 접근합니다.

(+)
- 게임 초대시 받는 사람이 보낸 사람을 block한 상태라면, 
보낸 사람은 보내진 것으로 처리되고(201 created response) 받는 사람은 'gameInvitation' 이벤트를 받지 않습니다.