### PR TITLE
fix: kick, ban, mute, admin 시 notice 소켓 이벤트 수정

### DIFF
--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -226,10 +226,11 @@ export class ChannelsController {
 		const giverUserId = user.id;
 		const receiverChannelUserId = updateChannelUserRequestDto.channelUserId;
 
-		const isAdmin = await this.channelsService.updateChannelUserType(
-			giverUserId,
-			receiverChannelUserId,
-		);
+		const { isAdmin, receiverUserProfile } =
+			await this.channelsService.updateChannelUserType(
+				giverUserId,
+				receiverChannelUserId,
+			);
 		// console.log(isAdmin);
 		const updateChannelUserTypeResponseDto = {
 			isAdmin: isAdmin,
@@ -242,7 +243,7 @@ export class ChannelsController {
 			);
 		this.channelsGateway.channelNoticeMessage(channelId, {
 			channelId,
-			nickname: user.nickname,
+			nickname: receiverUserProfile.nickname, // 관리자가 되거나 해제된 유저의 닉네임
 			eventType: isAdmin
 				? ChannelEventType.ADMIN
 				: ChannelEventType.ADMIN_CANCEL,
@@ -263,19 +264,18 @@ export class ChannelsController {
 		const giverUserId = user.id;
 		const receiverChannelUserId = updateChannelUserRequestDto.channelUserId;
 
-		await this.channelsService.kickChannelUser(
+		const receiverUserProfile = await this.channelsService.kickChannelUser(
 			giverUserId,
 			receiverChannelUserId,
 		);
 
 		// channelId를 찾아서 해당 채널에 join한 유저들에게 알림
-		const channelId =
-			await this.channelsService.findChannelIdByChannelUserId(
-				receiverChannelUserId,
-			);
+		const channelId = await this.channelsService.findChannelIdByUserId(
+			giverUserId,
+		);
 		this.channelsGateway.channelNoticeMessage(channelId, {
 			channelId,
-			nickname: user.nickname,
+			nickname: receiverUserProfile.nickname, // 강퇴당한 유저의 닉네임
 			eventType: ChannelEventType.KICK,
 		});
 	}
@@ -292,19 +292,18 @@ export class ChannelsController {
 		const giverUserId = user.id;
 		const receiverChannelUserId = updateChannelUserRequestDto.channelUserId;
 
-		await this.channelsService.banChannelUser(
+		const receiverUserProfile = await this.channelsService.banChannelUser(
 			giverUserId,
 			receiverChannelUserId,
 		);
 
 		// channelId를 찾아서 해당 채널에 join한 유저들에게 알림
-		const channelId =
-			await this.channelsService.findChannelIdByChannelUserId(
-				receiverChannelUserId,
-			);
+		const channelId = await this.channelsService.findChannelIdByUserId(
+			giverUserId,
+		);
 		this.channelsGateway.channelNoticeMessage(channelId, {
 			channelId,
-			nickname: user.nickname,
+			nickname: receiverUserProfile.nickname, // 밴 당한 유저의 닉네임
 			eventType: ChannelEventType.BAN,
 		});
 	}
@@ -320,7 +319,10 @@ export class ChannelsController {
 	) {
 		const receiverChannelUserId = updateChannelUserRequestDto.channelUserId;
 
-		await this.channelsService.muteChannelUser(user, receiverChannelUserId);
+		const receiverUserProfile = await this.channelsService.muteChannelUser(
+			user,
+			receiverChannelUserId,
+		);
 
 		// channelId를 찾아서 해당 채널에 join한 유저들에게 알림
 		const channelId =
@@ -329,7 +331,7 @@ export class ChannelsController {
 			);
 		this.channelsGateway.channelNoticeMessage(channelId, {
 			channelId,
-			nickname: user.nickname,
+			nickname: receiverUserProfile.nickname, // 뮤트 당한 유저의 닉네임
 			eventType: ChannelEventType.MUTE,
 		});
 	}

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -3,11 +3,7 @@ import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import * as bycrypt from 'bcrypt';
 import { Redis } from 'ioredis';
 import { MUTE_TIME } from 'src/common/constants';
-import {
-	ChannelEventType,
-	ChannelType,
-	ChannelUserType,
-} from 'src/common/enum';
+import { ChannelType, ChannelUserType } from 'src/common/enum';
 import { GatewayCreateChannelInvitationParamDto } from 'src/game/dto/gateway-create-channelInvitation-param-dto';
 import { User } from 'src/users/entities/user.entity';
 import { UsersRepository } from 'src/users/users.repository';
@@ -382,10 +378,11 @@ export class ChannelsService {
 			giverUserId,
 			channelId,
 		);
-		if (giverChannelUser.channelUserType !== ChannelUserType.OWNER)
+		if (giverChannelUser.channelUserType !== ChannelUserType.OWNER) {
 			throw new BadRequestException(
 				`giver ${giverUserId} does not have authority`,
 			);
+		}
 
 		// receiver user 유효성 확인 (존재하는 user인지)
 		const receiverUserId = receiverChannelUser.userId;
@@ -396,7 +393,14 @@ export class ChannelsService {
 			receiverChannelUserId,
 		);
 
-		return result.channelUserType === ChannelUserType.ADMIN;
+		const receiverUserProfile = await this.usersRepository.findOne({
+			where: { id: receiverUserId },
+		});
+
+		return {
+			isAdmin: result.channelUserType === ChannelUserType.ADMIN,
+			receiverUserProfile: receiverUserProfile!,
+		};
 	}
 
 	async kickChannelUser(giverUserId: number, receiverChannelUserId: number) {
@@ -435,9 +439,15 @@ export class ChannelsService {
 				);
 		}
 
+		const receiverUserProfile = await this.usersRepository.findOne({
+			where: { id: receiverUserId },
+		});
+
 		await this.channelUsersRepository.softDeleteUserFromChannel(
 			receiverChannelUserId,
 		);
+
+		return receiverUserProfile!;
 	}
 
 	async banChannelUser(giverUserId: number, receiverChannelUserId: number) {
@@ -477,6 +487,10 @@ export class ChannelsService {
 			}
 		}
 
+		const receiverUserProfile = await this.usersRepository.findOne({
+			where: { id: receiverUserId },
+		});
+
 		const result = await this.channelUsersRepository.update(
 			receiverChannelUserId,
 			{
@@ -489,6 +503,8 @@ export class ChannelsService {
 		await this.channelUsersRepository.softDeleteUserFromChannel(
 			receiverChannelUserId,
 		);
+
+		return receiverUserProfile!;
 	}
 
 	async muteChannelUser(giverUser: User, receiverChannelUserId: number) {
@@ -528,19 +544,18 @@ export class ChannelsService {
 			}
 		}
 
-		// await this.redis.set(`mute:${channelId}:${receiverUserIdKey}:1`, '');
-		// await this.redis.set(`mute:${channelId}:${receiverUserIdKey}:2`, '');
-		// await this.redis.expire(receiverUserIdKey, MUTE_TIME); // TODO: 30초로 변경
-		// const key = `mute:${channelId}:${receiverUserIdKey}:\*`;
-		// const Mutelist = await this.redis.keys(key);
-		// console.log('Mutelist: ', Mutelist);
+		const receiverUserProfile = await this.usersRepository.findOne({
+			where: { id: receiverUserId },
+		});
+
 		// redis에 mute 정보 저장
 		const muteKey = `mute:${channelId}:${receiverUser.id}`;
 		// redis에 mute 정보 저장
-		const result = await this.redis.set(muteKey, '');
+		await this.redis.set(muteKey, '');
 		// mute 정보 만료 시간 설정
 		await this.redis.expire(muteKey, MUTE_TIME); // TODO: 30초로 변경
-		console.log('result: ', result);
+
+		return receiverUserProfile!;
 	}
 
 	async findAllChannels(
@@ -718,8 +733,17 @@ export class ChannelsService {
 		const channelUser = await this.channelUsersRepository.findOne({
 			where: { id: channelUserId },
 		});
-		if (!channelUser)
+		if (!channelUser) {
 			throw new BadRequestException(`this ${channelUserId} is invalid`);
+		}
+
+		const user = await this.usersRepository.findOne({
+			where: { id: channelUser.userId },
+		});
+		if (!user) {
+			throw new BadRequestException(`user does not exist`);
+		}
+
 		return channelUser;
 	}
 
@@ -763,6 +787,16 @@ export class ChannelsService {
 			throw new BadRequestException(
 				`channelUser ${channelUserId} does not exist`,
 			);
+		}
+		return channelUser.channelId;
+	}
+
+	async findChannelIdByUserId(userId: number) {
+		const channelUser = await this.channelUsersRepository.findOne({
+			where: { userId },
+		});
+		if (!channelUser) {
+			throw new BadRequestException(`user ${userId} does not exist`);
 		}
 		return channelUser.channelId;
 	}


### PR DESCRIPTION
- kick, ban에서 channelId를 찾지 못하는 오류 수정
이미 삭제된 receiverChannelUser의 channelUserId 값을 이용해 channelId를 찾으려고 해서 발생하는 문제였습니다. giverUser의 userId 값을 이용해 channelId를 찾는 것으로 수정했습니다.
- kick, ban, mute, admin 시 소켓의 nickname을 receiver의 nickname으로 수정 #52
프론트의 요청으로 수정했습니다.

- 머지하고 sangyeki한테 알려주시면 감사하겠습니당