### PR TITLE
fix: kick, ban에서 channelId를 찾지 못하는 오류 수정 #52

### DIFF
--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -264,15 +264,18 @@ export class ChannelsController {
 		const giverUserId = user.id;
 		const receiverChannelUserId = updateChannelUserRequestDto.channelUserId;
 
+		const channelId =
+			await this.channelsService.findChannelIdByChannelUserId(
+				receiverChannelUserId,
+			);
+
+		// channelUser를 kick 처리한다.
 		const receiverUserProfile = await this.channelsService.kickChannelUser(
 			giverUserId,
 			receiverChannelUserId,
 		);
 
-		// channelId를 찾아서 해당 채널에 join한 유저들에게 알림
-		const channelId = await this.channelsService.findChannelIdByUserId(
-			giverUserId,
-		);
+		// 해당 채널에 join한 유저들에게 알림
 		this.channelsGateway.channelNoticeMessage(channelId, {
 			channelId,
 			nickname: receiverUserProfile.nickname, // 강퇴당한 유저의 닉네임
@@ -292,15 +295,18 @@ export class ChannelsController {
 		const giverUserId = user.id;
 		const receiverChannelUserId = updateChannelUserRequestDto.channelUserId;
 
+		const channelId =
+			await this.channelsService.findChannelIdByChannelUserId(
+				receiverChannelUserId,
+			);
+
+		// channelUser를 Ban 처리하고, 해당 유저가 속한 채널에서 나가게 한다.
 		const receiverUserProfile = await this.channelsService.banChannelUser(
 			giverUserId,
 			receiverChannelUserId,
 		);
 
-		// channelId를 찾아서 해당 채널에 join한 유저들에게 알림
-		const channelId = await this.channelsService.findChannelIdByUserId(
-			giverUserId,
-		);
+		// 해당 채널에 join한 유저들에게 알림
 		this.channelsGateway.channelNoticeMessage(channelId, {
 			channelId,
 			nickname: receiverUserProfile.nickname, // 밴 당한 유저의 닉네임

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -790,14 +790,4 @@ export class ChannelsService {
 		}
 		return channelUser.channelId;
 	}
-
-	async findChannelIdByUserId(userId: number) {
-		const channelUser = await this.channelUsersRepository.findOne({
-			where: { userId },
-		});
-		if (!channelUser) {
-			throw new BadRequestException(`user ${userId} does not exist`);
-		}
-		return channelUser.channelId;
-	}
 }


### PR DESCRIPTION
- channelId를 channelUser 엔티티에서 giverUserId로 찾으면 여러 채널에 나올 수 있습니다.
- receiverChannelUserId를 이용해 channelUserId를 찾되, 채널유저 삭제 이전에 수행하도록 순서를 변경했습니다.