### PR TITLE
feat(game): add game queue matchmaking logics

### DIFF
--- a/src/common/events.ts
+++ b/src/common/events.ts
@@ -8,6 +8,8 @@ export const EVENT_GAME_INVITATION_REPLY = 'gameInvitationReply';
 
 export const EVENT_SERVER_GAME_READY = 'serverGameReady';
 
+export const EVENT_GAME_MATCHED = 'gameMatched';
+
 export const EVENT_GAME_START = 'gameStart';
 
 export const EVENT_MATCH_SCORE = 'matchScore';

--- a/src/game/dto/emit-event-invitation-reaponse.dto.ts
+++ b/src/game/dto/emit-event-invitation-reaponse.dto.ts
@@ -1,0 +1,6 @@
+export class EmitEventInvitationReplyDto {
+	targetUserId: number;
+	targetUserChannelSocketId: string;
+	isAccepted: boolean;
+	gameId: number | null;
+}

--- a/src/game/dto/emit-event-matchmaking-param.dto.ts
+++ b/src/game/dto/emit-event-matchmaking-param.dto.ts
@@ -1,0 +1,5 @@
+export class EmitEventMatchmakingReplyDto {
+	targetUserId: number;
+	targetUserChannelSocketId: string;
+	gameId: number | null;
+}

--- a/src/game/dto/match-game-delete-param.dto.ts
+++ b/src/game/dto/match-game-delete-param.dto.ts
@@ -1,0 +1,6 @@
+import { GameType } from 'src/common/enum';
+
+export class gameMatchDeleteParamDto {
+	userId: number;
+	gameType: GameType;
+}

--- a/src/game/dto/match-game-param.dto.ts
+++ b/src/game/dto/match-game-param.dto.ts
@@ -1,0 +1,6 @@
+import { GameType } from 'src/common/enum';
+
+export class gameMatchStartParamDto {
+	userId: number;
+	gameType: GameType;
+}

--- a/src/game/game.controller.ts
+++ b/src/game/game.controller.ts
@@ -17,6 +17,9 @@ import { PositiveIntPipe } from '../common/pipes/positiveInt.pipe';
 import { AuthGuard } from '@nestjs/passport';
 import { DeleteGameInvitationParamDto } from './dto/delete-invitation-param.dto';
 import { acceptGameParamDto } from './dto/accept-game-param.dto';
+import { gameMatchStartParamDto } from './dto/match-game-param.dto';
+import { GameType } from 'src/common/enum';
+import { gameMatchDeleteParamDto } from './dto/match-game-delete-param.dto';
 
 @Controller('game')
 @ApiTags('game')
@@ -85,5 +88,32 @@ export class GameController {
 		await this.gameService.deleteInvitationByInvitedUserId(
 			deleteInvitationParamDto,
 		);
+	}
+
+	@Post('/match')
+	async gameMatchStart(
+		@GetUser() user: User,
+		@Body('gameType')
+		gameType: GameType,
+	) {
+		const gameMatchStartDto: gameMatchStartParamDto = {
+			userId: user.id,
+			gameType: gameType,
+		};
+		console.log(gameMatchStartDto);
+		await this.gameService.gameMatchStart(gameMatchStartDto);
+	}
+
+	@Delete('/match/:gameType')
+	async gameMatchCancel(
+		@GetUser() user: User,
+		@Param('gameType')
+		gameType: GameType,
+	) {
+		const gameDeleteMatchDto: gameMatchDeleteParamDto = {
+			userId: user.id,
+			gameType: gameType,
+		};
+		await this.gameService.gameMatchCancel(gameDeleteMatchDto);
 	}
 }

--- a/src/game/game.gateway.ts
+++ b/src/game/game.gateway.ts
@@ -20,6 +20,7 @@ import {
 	EVENT_MATCH_SCORE,
 	EVENT_MATCH_STATUS,
 	EVENT_SERVER_GAME_READY,
+	EVENT_GAME_MATCHED,
 } from '../common/events';
 import { ChannelsGateway } from '../channels/channels.gateway';
 import { EmitEventInvitationReplyDto } from './dto/emit-event-invitation-reply.dto';
@@ -30,6 +31,7 @@ import { GameStatus, UserStatus } from '../common/enum';
 import { EmitEventMatchStatusDto } from './dto/emit-event-match-status.dto';
 import { EmitEventMatchScoreParamDto } from './dto/emit-event-match-score-param.dto';
 import { EmitEventServerGameReadyParamDto } from './dto/emit-event-server-game-ready-param.dto';
+import { EmitEventMatchmakingReplyDto } from './dto/emit-event-matchmaking-param.dto';
 
 @WebSocketGateway({ namespace: 'game' })
 @UseFilters(WsExceptionFilter)
@@ -115,6 +117,20 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			.to(targetUserChannelSocketId)
 			.emit(EVENT_GAME_INVITATION_REPLY, {
 				isAccepted: isAccepted,
+				gameId: gameId,
+			});
+	}
+
+	async sendMatchmakingReply(
+		sendMatchmakingReplyDto: EmitEventMatchmakingReplyDto,
+	) {
+		const targetUserChannelSocketId =
+			sendMatchmakingReplyDto.targetUserChannelSocketId;
+		const gameId = sendMatchmakingReplyDto.gameId;
+
+		this.channelsGateway.server
+			.to(targetUserChannelSocketId)
+			.emit(EVENT_GAME_MATCHED, {
 				gameId: gameId,
 			});
 	}

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -7,15 +7,23 @@ import { GameGateway } from './game.gateway';
 import { CreateInitialGameParamDto } from './dto/create-initial-game-param.dto';
 import { GameInvitationRepository } from './game-invitation.repository';
 import { DeleteGameInvitationParamDto } from './dto/delete-invitation-param.dto';
-import { GameStatus, UserStatus } from '../common/enum';
+import { GameStatus, GameType, UserStatus } from '../common/enum';
 import { acceptGameParamDto } from './dto/accept-game-param.dto';
-import { EmitEventInvitationReplyDto } from './dto/emit-event-invitation-reply.dto';
+import { EmitEventInvitationReplyDto } from './dto/emit-event-invitation-reaponse.dto';
 import { User } from '../users/entities/user.entity';
 import * as moment from 'moment';
 import { BlocksRepository } from '../users/blocks.repository';
+import { gameMatchStartParamDto } from './dto/match-game-param.dto';
+import { EmitEventMatchmakingReplyDto } from './dto/emit-event-matchmaking-param.dto';
+import { gameMatchDeleteParamDto } from './dto/match-game-delete-param.dto';
 
 @Injectable()
 export class GameService {
+	private gameQueue: Record<string, User[]> = {
+		LADDER: [],
+		NORMAL_MATCHING: [],
+		SPECIAL_MATCHING: [],
+	};
 	constructor(
 		private readonly gameRepository: GameRepository,
 		private readonly gameInvitationRepository: GameInvitationRepository,
@@ -190,6 +198,108 @@ export class GameService {
 		);
 	}
 
+	async gameMatchStart(gameMatchStartParamDto: gameMatchStartParamDto) {
+		const userId = gameMatchStartParamDto.userId;
+		const gameType = gameMatchStartParamDto.gameType;
+
+		// 유저가 존재하는지
+		const user = await this.checkUserExist(userId);
+
+		if (user.status !== UserStatus.ONLINE || !user.channelSocketId)
+			throw new BadRequestException(
+				`유저 ${user.id} 는 OFFLINE 상태이거나 게임중입니다`,
+			);
+		if (
+			gameType !== GameType.LADDER &&
+			gameType !== GameType.NORMAL_MATCHING &&
+			gameType !== GameType.SPECIAL_MATCHING
+		) {
+			throw new BadRequestException(`지원하지 않는 게임 타입입니다`);
+		}
+
+		const gameQueue = this.gameQueue[gameType];
+
+		// 이미 큐에 존재하는지
+		const index = gameQueue.indexOf(user);
+		if (index > -1)
+			throw new BadRequestException(
+				`유저 ${user.id} 는 이미 매칭 큐에 존재합니다`,
+			);
+
+		gameQueue.push(user);
+
+		if (gameQueue.length === 2) {
+			const player1 = gameQueue[0];
+			const player2 = gameQueue[1];
+
+			if (
+				player1.channelSocketId === null ||
+				player2.channelSocketId === null
+			)
+				throw new BadRequestException(
+					`유저 ${player1.id} 는 OFFLINE 상태입니다`,
+				);
+
+			const gameDto = new CreateInitialGameParamDto(
+				player1.id,
+				player2.id,
+				gameType,
+				GameStatus.WAITING,
+			);
+			const game = await this.gameRepository.createGame(gameDto);
+
+			const invitationReplyToPlayer1Dto: EmitEventMatchmakingReplyDto = {
+				targetUserId: player1.id,
+				targetUserChannelSocketId: player1.channelSocketId,
+				gameId: game.id,
+			};
+			const invitationReplyToPlayer2Dto: EmitEventMatchmakingReplyDto = {
+				targetUserId: player2.id,
+				targetUserChannelSocketId: player2.channelSocketId,
+				gameId: game.id,
+			};
+
+			await this.gameGateway.sendMatchmakingReply(
+				invitationReplyToPlayer1Dto,
+			);
+			await this.gameGateway.sendMatchmakingReply(
+				invitationReplyToPlayer2Dto,
+			);
+			gameQueue.splice(0, 2);
+		}
+	}
+
+	async gameMatchCancel(gameMatchCancelParamDto: gameMatchDeleteParamDto) {
+		const userId = gameMatchCancelParamDto.userId;
+		const gameType = gameMatchCancelParamDto.gameType;
+
+		// 유저가 존재하는지
+		const user = await this.checkUserExist(userId);
+
+		if (user.status !== UserStatus.ONLINE || !user.channelSocketId)
+			throw new BadRequestException(
+				`유저 ${user.id} 는 OFFLINE 상태이거나 게임중입니다`,
+			);
+
+		if (
+			gameType !== GameType.LADDER &&
+			gameType !== GameType.NORMAL_MATCHING &&
+			gameType !== GameType.SPECIAL_MATCHING
+		) {
+			throw new BadRequestException(`지원하지 않는 게임 타입입니다`);
+		}
+
+		const gameQueue = this.gameQueue[gameType];
+
+		const index = gameQueue.indexOf(user);
+		if (index > -1) {
+			gameQueue.splice(index, 1);
+		} else if (index === -1)
+			throw new BadRequestException(
+				`유저 ${user.id} 는 매칭 큐에 존재하지 않습니다`,
+			);
+	}
+
 	async deleteInvitationByInvitingUserId(
 		deleteInvitationParamDto: DeleteGameInvitationParamDto,
 	) {
@@ -216,7 +326,6 @@ export class GameService {
 				`시간초과로 유효하지 않은 요청입니다`,
 			);
 		}
-
 		await this.gameInvitationRepository.softDelete(invitationId);
 	}
 

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -229,7 +229,6 @@ export class GameService {
 		gameQueue.push(user);
 
 		if (gameQueue.length >= 2) {
-			console.log(gameQueue);
 			let player1 = gameQueue.shift();
 			let player2 = gameQueue.shift();
 

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -228,16 +228,28 @@ export class GameService {
 
 		gameQueue.push(user);
 
-		if (gameQueue.length === 2) {
-			const player1 = gameQueue[0];
-			const player2 = gameQueue[1];
+		if (gameQueue.length >= 2) {
+			console.log(gameQueue);
+			let player1 = gameQueue.shift();
+			let player2 = gameQueue.shift();
+
+			// player1 또는 2가 OFFLINE이라면 큐에서 제거시키고 다시 매칭
+			while (player1 && player1.channelSocketId === null) {
+				player1 = gameQueue.shift();
+			}
+
+			while (player2 && player2.channelSocketId === null) {
+				player2 = gameQueue.shift();
+			}
 
 			if (
+				!player1 ||
+				!player2 ||
 				player1.channelSocketId === null ||
 				player2.channelSocketId === null
 			)
 				throw new BadRequestException(
-					`유저 ${player1.id} 는 OFFLINE 상태입니다`,
+					`게임 매칭 큐에 유저가 2명 이상이어야 합니다`,
 				);
 
 			const gameDto = new CreateInitialGameParamDto(
@@ -265,7 +277,6 @@ export class GameService {
 			await this.gameGateway.sendMatchmakingReply(
 				invitationReplyToPlayer2Dto,
 			);
-			gameQueue.splice(0, 2);
 		}
 	}
 


### PR DESCRIPTION
- 매치메이킹을 위한 게임 큐를 3가지 구성했습니다.
1.  래더게임 큐(LADDER)
2. 노말모드 게임 큐(NORMAL_MATCHING)
3. 스페셜모드 게임 큐(SPECIAL_MATCHING)

- 유저가 2명이상 존재하게 된다면 매치메이킹 로직을 통한 gameDB가 구성됩니다.
1. 게임 큐에서 유저가 2명 이상일때 gameQueue에서 유저를 뽑아서 할당해줍니다.(shift)
2. 뽑아온 유저중 channelSocketId가 존재하지 않는다면 gameQueue에 존재하는 다른유저를 뽑아와서 해당 player을 대체합니다.
3. 유저에게 gameId를 emit 해줍니다.

- 매치메이킹 취소로직을 구성했습니다.
1. gameType을 받고, 큐에 유저가 있는지 검사합니다.
2. 유저가 존재한다면, 유저를 큐에서 삭제합니다. (splice)
3. 유저가 존재하지 않는다면 매칭큐에 존재하지 않는다는 에러메세지를 던집니다.
