### PR TITLE
feat(game): clear gameQueue when client disconnected

### DIFF
--- a/src/channels/entities/channel.entity.ts
+++ b/src/channels/entities/channel.entity.ts
@@ -15,7 +15,7 @@ import {
 	CHANNEL_PASSWORD_REGEXP,
 } from 'src/common/constants';
 import { ChannelType } from 'src/common/enum';
-import { BeforeInsert, Column, Entity } from 'typeorm';
+import { BeforeInsert, BeforeUpdate, Column, Entity } from 'typeorm';
 
 @Entity()
 export class Channel extends BaseEntity {
@@ -45,6 +45,7 @@ export class Channel extends BaseEntity {
 	ownerId?: number | null;
 
 	@BeforeInsert()
+	@BeforeUpdate()
 	async hashPassword() {
 		if (this.password) {
 			try {

--- a/src/game/game.module.ts
+++ b/src/game/game.module.ts
@@ -18,6 +18,7 @@ import { Friend } from '../users/entities/friend.entity';
 import { ChannelsModule } from '../channels/channels.module';
 import { Block } from '../users/entities/block.entity';
 import { BlocksRepository } from '../users/blocks.repository';
+import { ChannelsGateway } from 'src/channels/channels.gateway';
 
 @Module({
 	imports: [
@@ -43,6 +44,7 @@ import { BlocksRepository } from '../users/blocks.repository';
 		GameRepository,
 		GameInvitationRepository,
 		UsersRepository,
+		ChannelsGateway,
 	],
 })
 export class GameModule {}

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -1,3 +1,4 @@
+import { ChannelsGateway } from 'src/channels/channels.gateway';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { GameRepository } from './game.repository';
 import { UsersRepository } from '../users/users.repository';
@@ -19,17 +20,13 @@ import { gameMatchDeleteParamDto } from './dto/match-game-delete-param.dto';
 
 @Injectable()
 export class GameService {
-	private gameQueue: Record<string, User[]> = {
-		LADDER: [],
-		NORMAL_MATCHING: [],
-		SPECIAL_MATCHING: [],
-	};
 	constructor(
 		private readonly gameRepository: GameRepository,
 		private readonly gameInvitationRepository: GameInvitationRepository,
 		private readonly gameGateway: GameGateway,
 		private readonly usersRepository: UsersRepository,
 		private readonly blocksRepository: BlocksRepository,
+		private readonly ChannelsGateway: ChannelsGateway,
 	) {}
 
 	async createInvitation(invitationParamDto: CreateGameInvitationParamDto) {
@@ -201,6 +198,8 @@ export class GameService {
 	async gameMatchStart(gameMatchStartParamDto: gameMatchStartParamDto) {
 		const userId = gameMatchStartParamDto.userId;
 		const gameType = gameMatchStartParamDto.gameType;
+		const gameQueueInit = this.ChannelsGateway.getGameQueue();
+		const gameQueue = gameQueueInit[gameType];
 
 		// 유저가 존재하는지
 		const user = await this.checkUserExist(userId);
@@ -216,8 +215,6 @@ export class GameService {
 		) {
 			throw new BadRequestException(`지원하지 않는 게임 타입입니다`);
 		}
-
-		const gameQueue = this.gameQueue[gameType];
 
 		// 이미 큐에 존재하는지
 		const index = gameQueue.indexOf(user);
@@ -282,6 +279,8 @@ export class GameService {
 	async gameMatchCancel(gameMatchCancelParamDto: gameMatchDeleteParamDto) {
 		const userId = gameMatchCancelParamDto.userId;
 		const gameType = gameMatchCancelParamDto.gameType;
+		const gameQueueInit = this.ChannelsGateway.getGameQueue();
+		const gameQueue = gameQueueInit[gameType];
 
 		// 유저가 존재하는지
 		const user = await this.checkUserExist(userId);
@@ -299,11 +298,14 @@ export class GameService {
 			throw new BadRequestException(`지원하지 않는 게임 타입입니다`);
 		}
 
-		const gameQueue = this.gameQueue[gameType];
-
-		const index = gameQueue.indexOf(user);
+		const index = gameQueue.findIndex(
+			(queueUser) => queueUser.id === user.id,
+		);
 		if (index > -1) {
 			gameQueue.splice(index, 1);
+			if (gameQueue.length === 0) {
+				return;
+			}
 		} else if (index === -1)
 			throw new BadRequestException(
 				`유저 ${user.id} 는 매칭 큐에 존재하지 않습니다`,


### PR DESCRIPTION
- client가 매칭을 돌리고 있는 상태에서 새로고침을 하게될 때 gameQueue에서 빠져나오지 않는 버그를 수정했습니다.
- 기존에는 한유저가 매칭버튼을 누르고 새로고침을 해서 매칭을 다시 돌리게 된다면 자신과의(?) 매칭이 이뤄졌습니다.
1. channelGateway에 gameQueue를 재배치시켰습니다. 이를 통해 순환 의존성을 줄이고, 채널에서 Disconnect해줄때 용이하도록 했습니다.
2. user정보를 받아서 래더, 노말매치, 스페셜매치를 모두 순회하여 유저를 배제시키는 방식으로 구성했습니다.

-'/match' Delete api 에서 유저삭제가 안되는 버그를 수정했습니다.
- 유저정보를 들고 있는 gameQueue에서 매칭 취소를 해도 gameQueue에서 빠져나오지 않았습니다. 
1. User정보의 객체를 찾기위해 user.id와 매칭해서 찾아야 하는방식으로 찾도록 구성했습니다.
2. gameQueue에 아무도 없다면 return 해서 매칭을 나올 수 있도록 구성했습니다.