### PR TITLE
fix(ranking): update ranking user only by cronjob

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -67,7 +67,6 @@ export class AuthController {
 			isMfaEnabled: user.isMfaEnabled,
 			mfaUrl,
 		};
-		await this.AppService.updateRanking(user.ladderScore, user.id);
 
 		return res.send(userSigninResponseDto);
 	}
@@ -159,10 +158,6 @@ export class AuthController {
 			isMfaEnabled: false,
 			mfaUrl: undefined,
 		};
-		Logger.log(
-			`updateRanking(ladderScore, id): ${user.ladderScore}, ${user.id}`,
-		);
-		await this.AppService.updateRanking(user.ladderScore, user.id); // TODO: 필요한 부분인가?
 
 		return res.send(userSigninResponseDto);
 	}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -67,6 +67,7 @@ export class AuthController {
 			isMfaEnabled: user.isMfaEnabled,
 			mfaUrl,
 		};
+		await this.AppService.updateRanking(user.ladderScore, user.id);
 
 		return res.send(userSigninResponseDto);
 	}

--- a/src/users/ranks.service.ts
+++ b/src/users/ranks.service.ts
@@ -6,6 +6,7 @@ import { AppService } from 'src/app.service';
 import { UsersRepository } from 'src/users/users.repository';
 import { RankUserResponseDto } from './dto/rank-user-response.dto';
 import { RankUserReturnDto } from './dto/rank-user-return.dto';
+import { IsNull, Not } from 'typeorm';
 @Injectable()
 export class RanksService {
 	constructor(
@@ -36,7 +37,11 @@ export class RanksService {
 
 	@Cron(CronExpression.EVERY_MINUTE)
 	async handleCron() {
-		const users = await this.userRepository.find();
+		const users = await this.userRepository.find(
+			// user중 nickname이 없는 유저는 랭킹에 올라가지 않는다.
+			{ where: { nickname: Not(IsNull()) } },
+		);
+		console.log(users);
 		for (const user of users) {
 			Logger.log(`updateRanking: ${user.ladderScore}, ${user.id}`);
 			await this.AppService.updateRanking(user.ladderScore, user.id);


### PR DESCRIPTION
- 유저랭킹을 업데이트 하는 방식을 한가지로 통일했습니다. 기존에는 두가지 방법으로 redis에 유저랭킹을 업데이트를 했습니다.
1. 최초로 유저 생성을 해주었을 때 바로 업데이트
2. 10분마다 크론잡 업데이트

닉네임이 업데이트 되지 않은 상황인데, DB에는 먼저 initializing 되는 경우가 생겼음
<img width="783" alt="KakaoTalk_Photo_2023-12-26-17-11-38" src="https://github.com/tscenping/BE/assets/83046766/d71b65b6-4476-4ebc-8fb3-18dfef51592e">

- 처음에 1번을 고려한 이유는 캐시와 DB의 데이터 일관성이 더 중요하다고 생각했었음
- 그러나 위 문제가 생기고 생각한건 정합성을 위반하지 않기위해 주기적으로만 잘 업데이트만 시켜주기만 하면 될 것 같다고 생각함
- 결론적으로, 닉네임이 초기화 되지 않은 유저는 크론에서 한번 걸러주고 랭킹에 업데이트 해주는 방식으로 통일하는 방식으로 구현함