### PR TITLE
feat: 채널 이름 수정 api 구현

### DIFF
--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -20,7 +20,7 @@ import { PositiveIntPipe } from '../common/pipes/positiveInt.pipe';
 import { ChannelsGateway } from './channels.gateway';
 import { ChannelsService } from './channels.service';
 import { ChannelInvitationParamDto } from './dto/channel-Invitation.dto';
-import { CreateChannelRequestDto } from './dto/creat-channel-request.dto';
+import { CreateChannelRequestDto } from './dto/create-channel-request.dto';
 import { CreateChannelUserParamDto } from './dto/create-channel-user-param.dto';
 import { CreateInvitationParamDto } from './dto/create-invitation-param.dto';
 import { CreateInvitationRequestDto } from './dto/create-invitation-request.dto';
@@ -29,6 +29,8 @@ import { JoinChannelRequestDto } from './dto/join-channel-request.dto';
 import { UpdateChannelPwdParamDto } from './dto/update-channel-pwd-param.dto';
 import { UpdateChannelPwdReqeustDto } from './dto/update-channel-pwd-reqeust.dto';
 import { UpdateChannelUserRequestDto } from './dto/update-channel-user-request.dto';
+import { UpdateChannelNameRequestDto } from './dto/update-channel-name-request.dto';
+import { UpdateChannelNameParamDto } from './dto/update-channel-name-param.dto';
 
 @Controller('channels')
 @ApiTags('channels')
@@ -100,30 +102,6 @@ export class ChannelsController {
 			);
 		}
 		return await this.channelsService.enterChannel(user.id, channelId);
-	}
-
-	@Patch('/password')
-	@ApiOperation({
-		summary: '비밀번호 설정/삭제',
-		description:
-			'채널 주인은 해당 채널에 합류하기 위한 패스워드를 생성, 삭제, 변경이 가능하다.',
-	})
-	async updateChannelPassword(
-		@GetUser() user: User,
-		@Body() updateChannelPwdRequestDto: UpdateChannelPwdReqeustDto,
-	) {
-		const channelId = updateChannelPwdRequestDto.channelId;
-		const userId = user.id;
-		const password = updateChannelPwdRequestDto.password;
-
-		const updateChannelPwdParam = new UpdateChannelPwdParamDto(
-			channelId,
-			userId,
-			password,
-		);
-		await this.channelsService.updateChannelTypeAndPassword(
-			updateChannelPwdParam,
-		);
 	}
 
 	@Post('/join')
@@ -211,6 +189,52 @@ export class ChannelsController {
 			invitedUserId,
 		);
 		await this.channelsService.createChannelInvitation(invitationParamDto);
+	}
+
+	@Patch('/name')
+	async updateChannelName(
+		@GetUser() user: User,
+		@Body() updateChannelNameRequestDto: UpdateChannelNameRequestDto,
+	) {
+		const channelId = updateChannelNameRequestDto.channelId;
+		const newName = updateChannelNameRequestDto.newName;
+		const updateChannelNameParamDto = new UpdateChannelNameParamDto(
+			channelId,
+			user.id,
+			newName,
+		);
+
+		await this.channelsService.updateChannelName(updateChannelNameParamDto);
+
+		this.channelsGateway.channelNameChangeMessage(channelId, {
+			channelId: channelId,
+			newName: newName,
+			eventType: ChannelEventType.NAME_CHANGE,
+		});
+	}
+
+	@Patch('/password')
+	@ApiOperation({
+		summary: '비밀번호 설정/삭제',
+		description:
+			'채널 주인은 해당 채널에 합류하기 위한 패스워드를 생성, 삭제, 변경이 가능하다.',
+	})
+	async updateChannelPassword(
+		@GetUser() user: User,
+		@Body() updateChannelPwdRequestDto: UpdateChannelPwdReqeustDto,
+	) {
+		const channelId = updateChannelPwdRequestDto.channelId;
+		const userId = user.id;
+		const password = updateChannelPwdRequestDto.password;
+
+		const updateChannelPwdParam = new UpdateChannelPwdParamDto(
+			channelId,
+			userId,
+			password,
+		);
+		await this.channelsService.updateChannelTypeAndPassword(
+			updateChannelPwdParam,
+		);
 	}
 
 	@Patch('/admin')

--- a/src/channels/channels.gateway.ts
+++ b/src/channels/channels.gateway.ts
@@ -32,6 +32,7 @@ import { EventMessageOnDto } from './dto/event-message-on.dto';
 import { User } from 'src/user-repository/entities/user.entity';
 import { WsAuthGuard } from '../common/guards/ws-auth.guard';
 import { SocketWithAuth } from '../common/adapter/socket-io.adapter';
+import { ChannelNameChangeResponseDto } from './dto/channel-name-change-response.dto';
 
 @WebSocketGateway({ namespace: 'channels' })
 @UseGuards(WsAuthGuard)
@@ -280,6 +281,15 @@ export class ChannelsGateway
 		this.server
 			.to(channelId.toString())
 			.emit('notice', channelNoticeResponseDto);
+	}
+
+	channelNameChangeMessage(
+		channelId: number,
+		channelNameChangeResponseDto: ChannelNameChangeResponseDto,
+	) {
+		this.server
+			.to(channelId.toString())
+			.emit('nameChange', channelNameChangeResponseDto);
 	}
 
 	private async isSocketConnected(ChannelSocketId: string) {

--- a/src/channels/dto/channel-name-change-response.dto.ts
+++ b/src/channels/dto/channel-name-change-response.dto.ts
@@ -1,0 +1,7 @@
+import { ChannelEventType } from 'src/common/enum';
+
+export type ChannelNameChangeResponseDto = {
+	channelId: number;
+	newName: string;
+	eventType: ChannelEventType;
+};

--- a/src/channels/dto/create-channel-request.dto.ts
+++ b/src/channels/dto/create-channel-request.dto.ts
@@ -22,7 +22,9 @@ export class CreateChannelRequestDto {
 	@Matches(CHANNEL_NAME_REGEXP)
 	name: string | null;
 
-	@ApiProperty({ description: '채널종류 (PUBLIC / PROTECTED / PRIVATE / DM)' })
+	@ApiProperty({
+		description: '채널종류 (PUBLIC / PROTECTED / PRIVATE / DM)',
+	})
 	@IsString()
 	@IsEnum(ChannelType)
 	channelType: ChannelType;

--- a/src/channels/dto/update-channel-name-param.dto.ts
+++ b/src/channels/dto/update-channel-name-param.dto.ts
@@ -1,0 +1,11 @@
+export class UpdateChannelNameParamDto {
+	channelId: number;
+	userId: number;
+	newName: string;
+
+	constructor(channelId: number, userId: number, newName: string) {
+		this.channelId = channelId;
+		this.userId = userId;
+		this.newName = newName;
+	}
+}

--- a/src/channels/dto/update-channel-name-request.dto.ts
+++ b/src/channels/dto/update-channel-name-request.dto.ts
@@ -1,0 +1,24 @@
+import { Column } from 'typeorm';
+import {
+	IsNotEmpty,
+	IsNumber,
+	IsPositive,
+	IsString,
+	Length,
+	Matches,
+} from 'class-validator';
+import { CHANNEL_NAME_REGEXP } from '../../common/constants';
+
+export class UpdateChannelNameRequestDto {
+	@Column()
+	@IsNumber()
+	@IsPositive()
+	@IsNotEmpty()
+	channelId: number;
+
+	@IsString()
+	@Length(1, 10)
+	@Matches(CHANNEL_NAME_REGEXP)
+	@IsNotEmpty()
+	newName: string;
+}

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -40,6 +40,7 @@ export enum ChannelEventType {
 	MUTE = 'MUTE',
 	ADMIN = 'ADMIN',
 	ADMIN_CANCEL = 'ADMIN_CANCEL',
+	NAME_CHANGE = 'NAME_CHANGE',
 }
 
 export enum KEYSTATUS {


### PR DESCRIPTION
* 채널 이름을 수정하는 api를 만들었습니다.
    * 이름 유효성 기준은 채널 생성할 때와 같습니다.
    * 채널 이름을 채널 유저들에게 알리는 nameChange 이벤트도 생겼습니다.