### PR TITLE
fix: privateAlert channelService에서 하기, 소켓 끊길 때 db 업데이트 잘하기, s3 이미지 api 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.0.1",
 			"license": "UNLICENSED",
 			"dependencies": {
+				"@aws-sdk/client-s3": "^3.554.0",
+				"@aws-sdk/s3-request-presigner": "^3.554.0",
 				"@liaoliaots/nestjs-redis": "^9.0.5",
 				"@nestjs/cache-manager": "^2.1.1",
 				"@nestjs/common": "^9.4.3",
@@ -184,6 +186,1012 @@
 			"engines": {
 				"node": ">=12.0.0"
 			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+			"integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+			"dependencies": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/crc32/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/crc32c": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+			"integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+			"dependencies": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/ie11-detection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/sha1-browser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+			"integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+			"dependencies": {
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+			"dependencies": {
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+			"dependencies": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@aws-sdk/client-s3": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.554.0.tgz",
+			"integrity": "sha512-d5TKKtGWhN0vl9QovUFrf3UsM7jgFQkowDPx1O+E/yeQUj1FBDOoRfDCcQOKW/9ghloI6k7f0bBpNxdd+x0oKA==",
+			"dependencies": {
+				"@aws-crypto/sha1-browser": "3.0.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.554.0",
+				"@aws-sdk/core": "3.554.0",
+				"@aws-sdk/credential-provider-node": "3.554.0",
+				"@aws-sdk/middleware-bucket-endpoint": "3.535.0",
+				"@aws-sdk/middleware-expect-continue": "3.535.0",
+				"@aws-sdk/middleware-flexible-checksums": "3.535.0",
+				"@aws-sdk/middleware-host-header": "3.535.0",
+				"@aws-sdk/middleware-location-constraint": "3.535.0",
+				"@aws-sdk/middleware-logger": "3.535.0",
+				"@aws-sdk/middleware-recursion-detection": "3.535.0",
+				"@aws-sdk/middleware-sdk-s3": "3.552.0",
+				"@aws-sdk/middleware-signing": "3.552.0",
+				"@aws-sdk/middleware-ssec": "3.537.0",
+				"@aws-sdk/middleware-user-agent": "3.540.0",
+				"@aws-sdk/region-config-resolver": "3.535.0",
+				"@aws-sdk/signature-v4-multi-region": "3.552.0",
+				"@aws-sdk/types": "3.535.0",
+				"@aws-sdk/util-endpoints": "3.540.0",
+				"@aws-sdk/util-user-agent-browser": "3.535.0",
+				"@aws-sdk/util-user-agent-node": "3.535.0",
+				"@aws-sdk/xml-builder": "3.535.0",
+				"@smithy/config-resolver": "^2.2.0",
+				"@smithy/core": "^1.4.2",
+				"@smithy/eventstream-serde-browser": "^2.2.0",
+				"@smithy/eventstream-serde-config-resolver": "^2.2.0",
+				"@smithy/eventstream-serde-node": "^2.2.0",
+				"@smithy/fetch-http-handler": "^2.5.0",
+				"@smithy/hash-blob-browser": "^2.2.0",
+				"@smithy/hash-node": "^2.2.0",
+				"@smithy/hash-stream-node": "^2.2.0",
+				"@smithy/invalid-dependency": "^2.2.0",
+				"@smithy/md5-js": "^2.2.0",
+				"@smithy/middleware-content-length": "^2.2.0",
+				"@smithy/middleware-endpoint": "^2.5.1",
+				"@smithy/middleware-retry": "^2.3.1",
+				"@smithy/middleware-serde": "^2.3.0",
+				"@smithy/middleware-stack": "^2.2.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/node-http-handler": "^2.5.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"@smithy/url-parser": "^2.2.0",
+				"@smithy/util-base64": "^2.3.0",
+				"@smithy/util-body-length-browser": "^2.2.0",
+				"@smithy/util-body-length-node": "^2.3.0",
+				"@smithy/util-defaults-mode-browser": "^2.2.1",
+				"@smithy/util-defaults-mode-node": "^2.3.1",
+				"@smithy/util-endpoints": "^1.2.0",
+				"@smithy/util-retry": "^2.2.0",
+				"@smithy/util-stream": "^2.2.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"@smithy/util-waiter": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-s3/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/client-sso": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.554.0.tgz",
+			"integrity": "sha512-yj6CgIxCT3UwMumEO481KH4QvwArkAPzD7Xvwe1QKgJATc9bKNEo/FxV8LfnWIJ7nOtMDxbNxYLMXH/Fs1qGaQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.554.0",
+				"@aws-sdk/middleware-host-header": "3.535.0",
+				"@aws-sdk/middleware-logger": "3.535.0",
+				"@aws-sdk/middleware-recursion-detection": "3.535.0",
+				"@aws-sdk/middleware-user-agent": "3.540.0",
+				"@aws-sdk/region-config-resolver": "3.535.0",
+				"@aws-sdk/types": "3.535.0",
+				"@aws-sdk/util-endpoints": "3.540.0",
+				"@aws-sdk/util-user-agent-browser": "3.535.0",
+				"@aws-sdk/util-user-agent-node": "3.535.0",
+				"@smithy/config-resolver": "^2.2.0",
+				"@smithy/core": "^1.4.2",
+				"@smithy/fetch-http-handler": "^2.5.0",
+				"@smithy/hash-node": "^2.2.0",
+				"@smithy/invalid-dependency": "^2.2.0",
+				"@smithy/middleware-content-length": "^2.2.0",
+				"@smithy/middleware-endpoint": "^2.5.1",
+				"@smithy/middleware-retry": "^2.3.1",
+				"@smithy/middleware-serde": "^2.3.0",
+				"@smithy/middleware-stack": "^2.2.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/node-http-handler": "^2.5.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"@smithy/url-parser": "^2.2.0",
+				"@smithy/util-base64": "^2.3.0",
+				"@smithy/util-body-length-browser": "^2.2.0",
+				"@smithy/util-body-length-node": "^2.3.0",
+				"@smithy/util-defaults-mode-browser": "^2.2.1",
+				"@smithy/util-defaults-mode-node": "^2.3.1",
+				"@smithy/util-endpoints": "^1.2.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"@smithy/util-retry": "^2.2.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.554.0.tgz",
+			"integrity": "sha512-M86rkiRqbZBF5VyfTQ/vttry9VSoQkZ1oCqYF+SAGlXmD0Of8587yRSj2M4rYe0Uj7nRQIfSnhDYp1UzsZeRfQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.554.0",
+				"@aws-sdk/core": "3.554.0",
+				"@aws-sdk/middleware-host-header": "3.535.0",
+				"@aws-sdk/middleware-logger": "3.535.0",
+				"@aws-sdk/middleware-recursion-detection": "3.535.0",
+				"@aws-sdk/middleware-user-agent": "3.540.0",
+				"@aws-sdk/region-config-resolver": "3.535.0",
+				"@aws-sdk/types": "3.535.0",
+				"@aws-sdk/util-endpoints": "3.540.0",
+				"@aws-sdk/util-user-agent-browser": "3.535.0",
+				"@aws-sdk/util-user-agent-node": "3.535.0",
+				"@smithy/config-resolver": "^2.2.0",
+				"@smithy/core": "^1.4.2",
+				"@smithy/fetch-http-handler": "^2.5.0",
+				"@smithy/hash-node": "^2.2.0",
+				"@smithy/invalid-dependency": "^2.2.0",
+				"@smithy/middleware-content-length": "^2.2.0",
+				"@smithy/middleware-endpoint": "^2.5.1",
+				"@smithy/middleware-retry": "^2.3.1",
+				"@smithy/middleware-serde": "^2.3.0",
+				"@smithy/middleware-stack": "^2.2.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/node-http-handler": "^2.5.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"@smithy/url-parser": "^2.2.0",
+				"@smithy/util-base64": "^2.3.0",
+				"@smithy/util-body-length-browser": "^2.2.0",
+				"@smithy/util-body-length-node": "^2.3.0",
+				"@smithy/util-defaults-mode-browser": "^2.2.1",
+				"@smithy/util-defaults-mode-node": "^2.3.1",
+				"@smithy/util-endpoints": "^1.2.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"@smithy/util-retry": "^2.2.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.554.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/client-sts": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.554.0.tgz",
+			"integrity": "sha512-EhaA6T0M0DNg5M8TCF1a7XJI5D/ZxAF3dgVIchyF98iNzjYgl/7U8K6hJay2A11aFvVu70g46xYMpz3Meky4wQ==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.554.0",
+				"@aws-sdk/middleware-host-header": "3.535.0",
+				"@aws-sdk/middleware-logger": "3.535.0",
+				"@aws-sdk/middleware-recursion-detection": "3.535.0",
+				"@aws-sdk/middleware-user-agent": "3.540.0",
+				"@aws-sdk/region-config-resolver": "3.535.0",
+				"@aws-sdk/types": "3.535.0",
+				"@aws-sdk/util-endpoints": "3.540.0",
+				"@aws-sdk/util-user-agent-browser": "3.535.0",
+				"@aws-sdk/util-user-agent-node": "3.535.0",
+				"@smithy/config-resolver": "^2.2.0",
+				"@smithy/core": "^1.4.2",
+				"@smithy/fetch-http-handler": "^2.5.0",
+				"@smithy/hash-node": "^2.2.0",
+				"@smithy/invalid-dependency": "^2.2.0",
+				"@smithy/middleware-content-length": "^2.2.0",
+				"@smithy/middleware-endpoint": "^2.5.1",
+				"@smithy/middleware-retry": "^2.3.1",
+				"@smithy/middleware-serde": "^2.3.0",
+				"@smithy/middleware-stack": "^2.2.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/node-http-handler": "^2.5.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"@smithy/url-parser": "^2.2.0",
+				"@smithy/util-base64": "^2.3.0",
+				"@smithy/util-body-length-browser": "^2.2.0",
+				"@smithy/util-body-length-node": "^2.3.0",
+				"@smithy/util-defaults-mode-browser": "^2.2.1",
+				"@smithy/util-defaults-mode-node": "^2.3.1",
+				"@smithy/util-endpoints": "^1.2.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"@smithy/util-retry": "^2.2.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.554.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sts/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.554.0.tgz",
+			"integrity": "sha512-JrG7ToTLeNf+/S3IiCUPVw9jEDB0DXl5ho8n/HwOa946mv+QyCepCuV2U/8f/1KAX0mD8Ufm/E4/cbCbFHgbSg==",
+			"dependencies": {
+				"@smithy/core": "^1.4.2",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/signature-v4": "^2.2.1",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.535.0.tgz",
+			"integrity": "sha512-XppwO8c0GCGSAvdzyJOhbtktSEaShg14VJKg8mpMa1XcgqzmcqqHQjtDWbx5rZheY1VdpXZhpEzJkB6LpQejpA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.552.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.552.0.tgz",
+			"integrity": "sha512-vsmu7Cz1i45pFEqzVb4JcFmAmVnWFNLsGheZc8SCptlqCO5voETrZZILHYIl4cjKkSDk3pblBOf0PhyjqWW6WQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/fetch-http-handler": "^2.5.0",
+				"@smithy/node-http-handler": "^2.5.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-stream": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.554.0.tgz",
+			"integrity": "sha512-BQenhg43S6TMJHxrdjDVdVF+HH5tA1op9ZYLyJrvV5nn7CCO4kyAkkOuSAv1NkL+RZsIkW0/vHTXwQOQw3cUsg==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.554.0",
+				"@aws-sdk/credential-provider-env": "3.535.0",
+				"@aws-sdk/credential-provider-process": "3.535.0",
+				"@aws-sdk/credential-provider-sso": "3.554.0",
+				"@aws-sdk/credential-provider-web-identity": "3.554.0",
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/credential-provider-imds": "^2.3.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/shared-ini-file-loader": "^2.4.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.554.0.tgz",
+			"integrity": "sha512-poX/+2OE3oxqp4f5MiaJh251p8l+bzcFwgcDBwz0e2rcpvMSYl9jw4AvGnCiG2bmf9yhNJdftBiS1A+KjxV0qA==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.535.0",
+				"@aws-sdk/credential-provider-http": "3.552.0",
+				"@aws-sdk/credential-provider-ini": "3.554.0",
+				"@aws-sdk/credential-provider-process": "3.535.0",
+				"@aws-sdk/credential-provider-sso": "3.554.0",
+				"@aws-sdk/credential-provider-web-identity": "3.554.0",
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/credential-provider-imds": "^2.3.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/shared-ini-file-loader": "^2.4.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.535.0.tgz",
+			"integrity": "sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/shared-ini-file-loader": "^2.4.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.554.0.tgz",
+			"integrity": "sha512-8QPpwBA31i/fZ7lDZJC4FA9EdxLg5SJ8sPB2qLSjp5UTGTYL2HRl0Eznkb7DXyp/wImsR/HFR1NxuFCCVotLCg==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.554.0",
+				"@aws-sdk/token-providers": "3.554.0",
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/shared-ini-file-loader": "^2.4.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.554.0.tgz",
+			"integrity": "sha512-HN54DzLjepw5ZWSF9ycGevhFTyg6pjLuLKy5Y8t/f1jFDComzYdGEDe0cdV9YO653W3+PQwZZGz09YVygGYBLg==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.554.0",
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-bucket-endpoint": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.535.0.tgz",
+			"integrity": "sha512-7sijlfQsc4UO9Fsl11mU26Y5f9E7g6UoNg/iJUBpC5pgvvmdBRO5UEhbB/gnqvOEPsBXyhmfzbstebq23Qdz7A==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@aws-sdk/util-arn-parser": "3.535.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-config-provider": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-expect-continue": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.535.0.tgz",
+			"integrity": "sha512-hFKyqUBky0NWCVku8iZ9+PACehx0p6vuMw5YnZf8FVgHP0fode0b/NwQY6UY7oor/GftvRsAlRUAWGNFEGUpwA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-flexible-checksums": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.535.0.tgz",
+			"integrity": "sha512-rBIzldY9jjRATxICDX7t77aW6ctqmVDgnuAOgbVT5xgHftt4o7PGWKoMvl/45hYqoQgxVFnCBof9bxkqSBebVA==",
+			"dependencies": {
+				"@aws-crypto/crc32": "3.0.0",
+				"@aws-crypto/crc32c": "3.0.0",
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/is-array-buffer": "^2.2.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.535.0.tgz",
+			"integrity": "sha512-0h6TWjBWtDaYwHMQJI9ulafeS4lLaw1vIxRjbpH0svFRt6Eve+Sy8NlVhECfTU2hNz/fLubvrUxsXoThaLBIew==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-location-constraint": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.535.0.tgz",
+			"integrity": "sha512-SxfS9wfidUZZ+WnlKRTCRn3h+XTsymXRXPJj8VV6hNRNeOwzNweoG3YhQbTowuuNfXf89m9v6meYkBBtkdacKw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.535.0.tgz",
+			"integrity": "sha512-huNHpONOrEDrdRTvSQr1cJiRMNf0S52NDXtaPzdxiubTkP+vni2MohmZANMOai/qT0olmEVX01LhZ0ZAOgmg6A==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.535.0.tgz",
+			"integrity": "sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3": {
+			"version": "3.552.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.552.0.tgz",
+			"integrity": "sha512-9KzOqsbwJJuQcpmrpkkIftjPahB1bsrcWalYzcVqKCgHCylhkSHW2tX+uGHRnvAl9iobQD5D7LUrS+cv0NeQ/Q==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@aws-sdk/util-arn-parser": "3.535.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/signature-v4": "^2.2.1",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-config-provider": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-signing": {
+			"version": "3.552.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.552.0.tgz",
+			"integrity": "sha512-ZjOrlEmwjhbmkINa4Zx9LJh+xb/kgEiUrcfud2kq/r8ath1Nv1/4zalI9jHnou1J+R+yS+FQlXLXHSZ7vqyFbA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/signature-v4": "^2.2.1",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-ssec": {
+			"version": "3.537.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.537.0.tgz",
+			"integrity": "sha512-2QWMrbwd5eBy5KCYn9a15JEWBgrK2qFEKQN2lqb/6z0bhtevIOxIRfC99tzvRuPt6nixFQ+ynKuBjcfT4ZFrdQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.540.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.540.0.tgz",
+			"integrity": "sha512-8Rd6wPeXDnOYzWj1XCmOKcx/Q87L0K1/EHqOBocGjLVbN3gmRxBvpmR1pRTjf7IsWfnnzN5btqtcAkfDPYQUMQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@aws-sdk/util-endpoints": "3.540.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.535.0.tgz",
+			"integrity": "sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-config-provider": "^2.3.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/s3-request-presigner": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.554.0.tgz",
+			"integrity": "sha512-499skN4HpUNXasxmCnuiAuBvx3SzYLKK0WnfXk8cnEZq13981c8lDZRjSwOBCxGl5M3bCht2wiJ2fmjz/HtYWQ==",
+			"dependencies": {
+				"@aws-sdk/signature-v4-multi-region": "3.552.0",
+				"@aws-sdk/types": "3.535.0",
+				"@aws-sdk/util-format-url": "3.535.0",
+				"@smithy/middleware-endpoint": "^2.5.1",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/s3-request-presigner/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.552.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.552.0.tgz",
+			"integrity": "sha512-cC11/5ahp+LaBCq7cR+51AM2ftf6m9diRd2oWkbEpjSiEKQzZRAltUPZAJM6NXGypmDODQDJphLGt45tvS+8kg==",
+			"dependencies": {
+				"@aws-sdk/middleware-sdk-s3": "3.552.0",
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/signature-v4": "^2.2.1",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.554.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.554.0.tgz",
+			"integrity": "sha512-KMMQ5Cw0FUPL9H8g69Lp08xtzRo7r/MK+lBV6LznWBbCP/NwtZ8awVHaPy2P31z00cWtu9MYkUTviWPqJTaBvg==",
+			"dependencies": {
+				"@aws-sdk/client-sso-oidc": "3.554.0",
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/shared-ini-file-loader": "^2.4.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+			"integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/util-arn-parser": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.535.0.tgz",
+			"integrity": "sha512-smVo29nUPAOprp8Z5Y3GHuhiOtw6c8/EtLCm5AVMtRsTPw4V414ZXL2H66tzmb5kEeSzQlbfBSBEdIFZoxO9kg==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-arn-parser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.540.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.540.0.tgz",
+			"integrity": "sha512-1kMyQFAWx6f8alaI6UT65/5YW/7pDWAKAdNwL6vuJLea03KrZRX3PMoONOSJpAS5m3Ot7HlWZvf3wZDNTLELZw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-endpoints": "^1.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.535.0.tgz",
+			"integrity": "sha512-ElbNkm0bddu53CuW44Iuux1ZbTV50fydbSh/4ypW3LrmUvHx193ogj0HXQ7X26kmmo9rXcsrLdM92yIeTjidVg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/querystring-builder": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.535.0.tgz",
+			"integrity": "sha512-PHJ3SL6d2jpcgbqdgiPxkXpu7Drc2PYViwxSIqvvMKhDwzSB1W3mMvtpzwKM4IE7zLFodZo0GKjJ9AsoXndXhA==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.535.0.tgz",
+			"integrity": "sha512-RWMcF/xV5n+nhaA/Ff5P3yNP3Kur/I+VNZngog4TEs92oB/nwOdAg/2JL8bVAhUbMrjTjpwm7PItziYFQoqyig==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/types": "^2.12.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.535.0.tgz",
+			"integrity": "sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.535.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@aws-sdk/util-utf8-browser": {
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+			"dependencies": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.535.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.535.0.tgz",
+			"integrity": "sha512-VXAq/Jz8KIrU84+HqsOJhIKZqG0PNTdi6n6PFQ4xJf44ZQHD/5C7ouH4qCFX5XgZXcgbRIcMVVYGC6Jye0dRng==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.23.5",
@@ -2276,6 +3284,900 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
+		"node_modules/@smithy/abort-controller": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+			"integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/abort-controller/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/chunked-blob-reader": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.2.0.tgz",
+			"integrity": "sha512-3GJNvRwXBGdkDZZOGiziVYzDpn4j6zfyULHMDKAGIUo72yHALpE9CbhfQp/XcLNVoc1byfMpn6uW5H2BqPjgaQ==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@smithy/chunked-blob-reader-native": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.2.0.tgz",
+			"integrity": "sha512-VNB5+1oCgX3Fzs072yuRsUoC2N4Zg/LJ11DTxX3+Qu+Paa6AmbIF0E9sc2wthz9Psrk/zcOlTCyuposlIhPjZQ==",
+			"dependencies": {
+				"@smithy/util-base64": "^2.3.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@smithy/chunked-blob-reader-native/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/chunked-blob-reader/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/config-resolver": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+			"integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-config-provider": "^2.3.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/config-resolver/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/core": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.2.tgz",
+			"integrity": "sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==",
+			"dependencies": {
+				"@smithy/middleware-endpoint": "^2.5.1",
+				"@smithy/middleware-retry": "^2.3.1",
+				"@smithy/middleware-serde": "^2.3.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/core/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+			"integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/url-parser": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+			"integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+			"dependencies": {
+				"@aws-crypto/crc32": "3.0.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-hex-encoding": "^2.2.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/eventstream-serde-browser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.2.0.tgz",
+			"integrity": "sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.2.0.tgz",
+			"integrity": "sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-config-resolver/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/eventstream-serde-node": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+			"integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/eventstream-serde-universal": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+			"integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
+			"dependencies": {
+				"@smithy/eventstream-codec": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-universal/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+			"integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+			"dependencies": {
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/querystring-builder": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-base64": "^2.3.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/hash-blob-browser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.2.0.tgz",
+			"integrity": "sha512-SGPoVH8mdXBqrkVCJ1Hd1X7vh1zDXojNN1yZyZTZsCno99hVue9+IYzWDjq/EQDDXxmITB0gBmuyPh8oAZSTcg==",
+			"dependencies": {
+				"@smithy/chunked-blob-reader": "^2.2.0",
+				"@smithy/chunked-blob-reader-native": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@smithy/hash-blob-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+			"integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-buffer-from": "^2.2.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/hash-stream-node": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.2.0.tgz",
+			"integrity": "sha512-aT+HCATOSRMGpPI7bi7NSsTNVZE/La9IaxLXWoVAYMxHT5hGO3ZOGEMZQg8A6nNL+pdFGtZQtND1eoY084HgHQ==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-stream-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+			"integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/md5-js": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.2.0.tgz",
+			"integrity": "sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@smithy/md5-js/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+			"integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+			"dependencies": {
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+			"integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+			"dependencies": {
+				"@smithy/middleware-serde": "^2.3.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/shared-ini-file-loader": "^2.4.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/url-parser": "^2.2.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+			"integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/service-error-classification": "^2.1.5",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"@smithy/util-retry": "^2.2.0",
+				"tslib": "^2.6.2",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/middleware-retry/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+			"integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-serde/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+			"integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+			"integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+			"dependencies": {
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/shared-ini-file-loader": "^2.4.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+			"integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+			"dependencies": {
+				"@smithy/abort-controller": "^2.2.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/querystring-builder": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+			"integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+			"integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+			"integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-uri-escape": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+			"integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+			"integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+			"integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.3.0.tgz",
+			"integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-hex-encoding": "^2.2.0",
+				"@smithy/util-middleware": "^2.2.0",
+				"@smithy/util-uri-escape": "^2.2.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+			"integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+			"dependencies": {
+				"@smithy/middleware-endpoint": "^2.5.1",
+				"@smithy/middleware-stack": "^2.2.0",
+				"@smithy/protocol-http": "^3.3.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-stream": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/types": {
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+			"integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/types/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/url-parser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+			"integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+			"dependencies": {
+				"@smithy/querystring-parser": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@smithy/url-parser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+			"integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-base64/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-body-length-browser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+			"integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-body-length-node": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+			"integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+			"integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-config-provider/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+			"integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+			"dependencies": {
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+			"integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+			"dependencies": {
+				"@smithy/config-resolver": "^2.2.0",
+				"@smithy/credential-provider-imds": "^2.3.0",
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/property-provider": "^2.2.0",
+				"@smithy/smithy-client": "^2.5.1",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-endpoints": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.2.0.tgz",
+			"integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.3.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-endpoints/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-hex-encoding": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+			"integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-middleware": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+			"integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+			"dependencies": {
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-middleware/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-retry": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+			"integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+			"dependencies": {
+				"@smithy/service-error-classification": "^2.1.5",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-retry/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+			"integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^2.5.0",
+				"@smithy/node-http-handler": "^2.5.0",
+				"@smithy/types": "^2.12.0",
+				"@smithy/util-base64": "^2.3.0",
+				"@smithy/util-buffer-from": "^2.2.0",
+				"@smithy/util-hex-encoding": "^2.2.0",
+				"@smithy/util-utf8": "^2.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-stream/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+			"integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/@smithy/util-waiter": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.2.0.tgz",
+			"integrity": "sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==",
+			"dependencies": {
+				"@smithy/abort-controller": "^2.2.0",
+				"@smithy/types": "^2.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-waiter/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
 		"node_modules/@socket.io/component-emitter": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
@@ -3498,6 +5400,11 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+		},
+		"node_modules/bowser": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -5007,6 +6914,27 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
 			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+			"integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+			"funding": [
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
 		},
 		"node_modules/fastq": {
 			"version": "1.15.0",
@@ -8891,6 +10819,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/strnum": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
 		"node_modules/superagent": {
 			"version": "8.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
 		"test:e2e": "NODE_ENV=test jest --watch --no-cache --config ./test/jest-e2e.json"
 	},
 	"dependencies": {
+		"@aws-sdk/client-s3": "^3.554.0",
+		"@aws-sdk/s3-request-presigner": "^3.554.0",
 		"@liaoliaots/nestjs-redis": "^9.0.5",
 		"@nestjs/cache-manager": "^2.1.1",
 		"@nestjs/common": "^9.4.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { UserRepositoryModule } from './user-repository/user-repository.module';
 import { FriendsModule } from './friends/friends.module';
 import userConfig from './config/user.config';
 import googleConfig from './config/google.config';
+import s3Config from './config/s3.config';
 
 @Module({
 	imports: [
@@ -36,6 +37,7 @@ import googleConfig from './config/google.config';
 				jwtConfig,
 				typeOrmConfig,
 				userConfig,
+				s3Config,
 			],
 		}),
 		TypeOrmModule.forRootAsync({

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,11 +1,4 @@
-import {
-	Body,
-	Controller,
-	Patch,
-	Post,
-	Res,
-	UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Patch, Post, Res, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';

--- a/src/auth/dto/user-signin-response.dto.ts
+++ b/src/auth/dto/user-signin-response.dto.ts
@@ -1,6 +1,6 @@
 export type UserSigninResponseDto = {
 	userId: number;
-	nickname: string;
+	nickname: string | null;
 	isFirstLogin: boolean;
 	isMfaEnabled: boolean;
 	mfaUrl?: string;

--- a/src/channels/channel-invitation.repository.ts
+++ b/src/channels/channel-invitation.repository.ts
@@ -17,7 +17,7 @@ export class ChannelInvitationRepository extends Repository<ChannelInvitation> {
 	) {
 		const channelInvitation = this.create({
 			channelId: createChannelInvitationParamDto.channelId,
-			invitingUserId: createChannelInvitationParamDto.invitingUserId,
+			invitingUserId: createChannelInvitationParamDto.invitingUser.id,
 			invitedUserId: createChannelInvitationParamDto.invitedUserId,
 		});
 		const result = await this.save(channelInvitation);
@@ -27,8 +27,12 @@ export class ChannelInvitationRepository extends Repository<ChannelInvitation> {
 		return result;
 	}
 
-	async deleteChannelInvitation(deleteChannelInvitation: DeleteChannelInvitationParamDto) {
-		const result = await this.softDelete(deleteChannelInvitation.invitationId);
+	async deleteChannelInvitation(
+		deleteChannelInvitation: DeleteChannelInvitationParamDto,
+	) {
+		const result = await this.softDelete(
+			deleteChannelInvitation.invitationId,
+		);
 		if (result.affected !== 1)
 			throw DBUpdateFailureException('delete channel invitation failed');
 	}

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -179,12 +179,11 @@ export class ChannelsController {
 		@GetUser() user: User,
 		@Body() createInvitationRequestDto: CreateInvitationRequestDto,
 	) {
-		const invitingUserId = user.id;
 		const channelId = createInvitationRequestDto.channelId;
 		const invitedUserId = createInvitationRequestDto.invitedUserId;
 
 		const invitationParamDto = new CreateInvitationParamDto(
-			invitingUserId,
+			user,
 			channelId,
 			invitedUserId,
 		);

--- a/src/channels/channels.module.ts
+++ b/src/channels/channels.module.ts
@@ -9,8 +9,6 @@ import { ChannelsService } from './channels.service';
 import { ChannelInvitation } from './entities/channel-invitation.entity';
 import { ChannelUser } from './entities/channel-user.entity';
 import { Channel } from './entities/channel.entity';
-import { UsersModule } from '../users/users.module';
-import { AuthModule } from '../auth/auth.module';
 import { UserRepositoryModule } from '../user-repository/user-repository.module';
 import { FriendsModule } from '../friends/friends.module';
 import { JwtModule } from '@nestjs/jwt';

--- a/src/channels/dto/create-invitation-param.dto.ts
+++ b/src/channels/dto/create-invitation-param.dto.ts
@@ -1,14 +1,12 @@
+import { User } from '../../user-repository/entities/user.entity';
+
 export class CreateInvitationParamDto {
-	invitingUserId: number;
+	invitingUser: User;
 	channelId: number;
 	invitedUserId: number;
 
-	constructor(
-		invitingUserId: number,
-		channelId: number,
-		invitedUserId: number,
-	) {
-		this.invitingUserId = invitingUserId;
+	constructor(invitingUser: User, channelId: number, invitedUserId: number) {
+		this.invitingUser = invitingUser;
 		this.channelId = channelId;
 		this.invitedUserId = invitedUserId;
 	}

--- a/src/common/guards/ws-auth.guard.ts
+++ b/src/common/guards/ws-auth.guard.ts
@@ -40,6 +40,7 @@ export class WsAuthGuard implements CanActivate {
 		if (!user) throw new UnauthorizedException('no user');
 
 		socket.user = user;
+		console.log('user in WsAuthGuard', JSON.stringify(user));
 		return true;
 	}
 }

--- a/src/config/redis.config.ts
+++ b/src/config/redis.config.ts
@@ -1,18 +1,17 @@
-import {
-  RedisModuleOptions
-} from '@liaoliaots/nestjs-redis';
+import { RedisModuleOptions } from '@liaoliaots/nestjs-redis';
 import { registerAs } from '@nestjs/config';
 import { z } from 'zod';
 
 export default registerAs('redis', () => {
-  const REDIS_HOST = z.string().parse(process.env.REDIS_HOSTNAME);
-  const REDIS_PORT = parseInt(z.string().parse(process.env.REDIS_PORT), 10);
-  const REDIS_URL = z.string().parse(process.env.REDIS_URL);
+	const REDIS_HOST = z.string().parse(process.env.REDIS_HOSTNAME);
+	const REDIS_PORT = parseInt(z.string().parse(process.env.REDIS_PORT), 10);
+	const REDIS_URL = z.string().parse(process.env.REDIS_URL);
 
-  return {
-    config: {
-    host: REDIS_HOST,
-    port: REDIS_PORT,
-    url: REDIS_URL, }
-  } satisfies RedisModuleOptions;
+	return {
+		config: {
+			host: REDIS_HOST,
+			port: REDIS_PORT,
+			url: REDIS_URL,
+		},
+	} satisfies RedisModuleOptions;
 });

--- a/src/config/s3.config.ts
+++ b/src/config/s3.config.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { registerAs } from '@nestjs/config';
+import { S3Client } from '@aws-sdk/client-s3';
+
+export default registerAs('s3', () => {
+	const S3_BUCKET_NAME = z.string().parse(process.env.S3_BUCKET_NAME);
+	const S3Object = new S3Client({
+		region: z.string().parse(process.env.S3_REGION),
+		credentials: {
+			accessKeyId: z.string().parse(process.env.S3_ACCESS_KEY_ID),
+			secretAccessKey: z.string().parse(process.env.S3_SECRET_ACCESS_KEY),
+		},
+	});
+
+	return {
+		S3_BUCKET_NAME,
+		S3Object,
+	};
+});

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -8,14 +8,16 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
  */
 
 export function setupSwagger(app: INestApplication): void {
-  const options = new DocumentBuilder()
-    .setTitle('˗ˋˏ♡ˎˊ˗트 센 핑˗ˋˏ♡ˎˊ˗')
-    .setDescription('문서화 하기 귀찮은 P들을 위한 API 문서\n' +
-    'figma: https://www.figma.com/file/VdfgO5Us78FYGws6sEjRgA/tscenping?type=design&node-id=17-106&mode=design&t=9nlxXQ5yhqzFl3jm-0')
-    .setVersion('1.0.0')
-    .addTag('TSC')
-    .build();
-  const document = SwaggerModule.createDocument(app, options);
-  SwaggerModule.setup('swagger', app, document);
-  console.log('Swagger is running on https://localhost:3000/swagger')
+	const options = new DocumentBuilder()
+		.setTitle('˗ˋˏ♡ˎˊ˗트 센 핑˗ˋˏ♡ˎˊ˗')
+		.setDescription(
+			'문서화 하기 귀찮은 P들을 위한 API 문서\n' +
+				'figma: https://www.figma.com/file/VdfgO5Us78FYGws6sEjRgA/tscenping?type=design&node-id=17-106&mode=design&t=9nlxXQ5yhqzFl3jm-0',
+		)
+		.setVersion('1.0.0')
+		.addTag('TSC')
+		.build();
+	const document = SwaggerModule.createDocument(app, options);
+	SwaggerModule.setup('swagger', app, document);
+	console.log('Swagger is running on https://localhost:3000/swagger');
 }

--- a/src/game/game.gateway.ts
+++ b/src/game/game.gateway.ts
@@ -112,7 +112,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 	async handleDisconnect(@ConnectedSocket() client: SocketWithAuth) {
 		// 끊기고 실행되는 로직. .
 		const user = client.user;
-		if (!user || client.id !== user.gameSocketId) return;
+		if (!user || !client.id) return;
 
 		console.log(
 			`${user.id}, ${user.nickname} is disconnected to game socket {${client.id}}`,


### PR DESCRIPTION
1. privateAlert에서 던져지는 에러가 문제를 일으켰습니다
- 그래서 ChannelGateway에서 초대한 유저와 받은 유저가 유효한지를 검사하는게 맞나? 의문이 들어서 privateAlert 함수의 로직을 ChannelService로 옮겼읍니다.

2. 채널 소켓이 disconnect될 때 db를 업데이트하지 못하는 문제가 있었습니다.
- 예전에 발견했던 문제입니다 handleDisconnect에 WsAuthGuard가 적용되지 않습니다 그래서 연결시 socketIoAdapter에서 넣어줬던 user 객체를 그대로 씁니다. user의 channelSocketId가 null이어서 if (!user || client.id !== user.channelSocketId) 조건문에 걸리는 것이었습니다.  진짜 의도는 이게 이미 끊긴 client인지 거르는 것이라 생각해서 단순하게 if (!user || !client.id)로 바꿨습니다. 

3. 외부의 s3 버킷 접근을 위한 preSignedUrl 을 발급해주는 api들을 추가했습니다.