### PR TITLE
fix: s3 image 업로드 로직 수정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -111,7 +111,13 @@ export class AuthController {
 		const nickname = signupRequestDto.nickname;
 		const avatar = signupRequestDto.avatar;
 
-		return await this.authService.signup(user.id, nickname, avatar);
+		const preSignedUrl = await this.authService.signup(
+			user.id,
+			nickname,
+			avatar,
+		);
+
+		return { preSignedUrl: preSignedUrl };
 	}
 
 	// TODO: 테스트용 코드. 추후 삭제

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -111,7 +111,7 @@ export class AuthController {
 		const nickname = signupRequestDto.nickname;
 		const avatar = signupRequestDto.avatar;
 
-		await this.authService.signup(user.id, nickname, avatar);
+		return await this.authService.signup(user.id, nickname, avatar);
 	}
 
 	// TODO: 테스트용 코드. 추후 삭제

--- a/src/auth/dto/signup-request.dto.ts
+++ b/src/auth/dto/signup-request.dto.ts
@@ -5,8 +5,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class SignupRequestDto {
 	@ApiProperty({ description: '아바타' })
 	@IsNotEmpty()
-	@IsString()
-	avatar: string;
+	avatar: boolean;
 	@ApiProperty({ description: '닉네임' })
 	@IsNotEmpty()
 	@IsString()

--- a/src/channels/dto/channel-Invitation-list-return.dto.ts
+++ b/src/channels/dto/channel-Invitation-list-return.dto.ts
@@ -2,18 +2,18 @@ import { ApiProperty } from '@nestjs/swagger';
 import { ChannelUserType } from 'src/common/enum';
 
 export class ChannelInvitationListDto {
-    @ApiProperty({ description: '채널유저id' })
-    channelUserId: number;
-    @ApiProperty({ description: '유저id' })
-    userId : number;
-    @ApiProperty({ description: '유저닉네임' })
-    nickname : string;
-    @ApiProperty({ description: '유저아바타' })
-    avatar : string;
-    @ApiProperty({ description: '친구여부' })
-    isFriend : boolean;
-    @ApiProperty({ description: '차단여부' })
-    isBlocked : boolean;
-    @ApiProperty({ description: '채널유저타입' })
-    channelUserType : ChannelUserType;
+	@ApiProperty({ description: '채널유저id' })
+	channelUserId: number;
+	@ApiProperty({ description: '유저id' })
+	userId: number;
+	@ApiProperty({ description: '유저닉네임' })
+	nickname: string;
+	@ApiProperty({ description: '유저아바타' })
+	avatar: string | null;
+	@ApiProperty({ description: '친구여부' })
+	isFriend: boolean;
+	@ApiProperty({ description: '차단여부' })
+	isBlocked: boolean;
+	@ApiProperty({ description: '채널유저타입' })
+	channelUserType: ChannelUserType;
 }

--- a/src/channels/dto/channel-user-info-return.dto.ts
+++ b/src/channels/dto/channel-user-info-return.dto.ts
@@ -4,7 +4,7 @@ export type ChannelUserInfoReturnDto = {
 	channelUserId: number;
 	userId: number;
 	nickname: string;
-	avatar: string;
+	avatar: string | null;
 	isFriend: boolean;
 	isBlocked: boolean;
 	channelUserType: ChannelUserType;

--- a/src/channels/dto/dmchannel-list-return.dto.ts
+++ b/src/channels/dto/dmchannel-list-return.dto.ts
@@ -1,6 +1,6 @@
 export class DmChannelListReturnDto {
-    channelId: number;
-    partnerName: string;
-    status: string;
-    avatar: string;
+	channelId: number;
+	partnerName: string;
+	status: string;
+	avatar: string | null;
 }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -20,3 +20,10 @@ export const CHANNEL_NAME_REGEXP = /^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]*$/;
 /* If K is of a lower value, then the rating is changed by a small fraction 
 but if K is of a higher value, then the changes in the rating are significant.*/
 export const K = 30;
+
+export const S3_IMAGE_URL_PREFIX = 'https://d5xph0h5q8hbn.cloudfront.net';
+
+export const S3_OBJECT_KEY_PREFIX = 'image';
+export const S3_OBJECT_KEY_SUFFIX = '.jpeg';
+
+export const S3_OBJECT_CONTENTTYPE = 'image/jpeg';

--- a/src/friends/dto/block-user-return.dto.ts
+++ b/src/friends/dto/block-user-return.dto.ts
@@ -7,8 +7,7 @@ export class BlockUserReturnDto {
 	@ApiProperty({ description: '닉네임' })
 	nickname: string;
 	@ApiProperty({ description: '아바타' })
-	@IsNotEmpty()
-	avatar: string;
+	avatar: string | null;
 	@ApiProperty({ description: '상태(온라인 / 오프라인 / 인게임)' })
 	status: string;
 }

--- a/src/friends/dto/friend-user-return.dto.ts
+++ b/src/friends/dto/friend-user-return.dto.ts
@@ -1,6 +1,6 @@
 export type FriendUserReturnDto = {
 	id: number;
 	nickname: string;
-	avatar: string;
+	avatar: string | null;
 	status: string;
 };

--- a/src/game/dto/emit-event-match-end-param.dto.ts
+++ b/src/game/dto/emit-event-match-end-param.dto.ts
@@ -3,7 +3,7 @@ import { GameType } from '../../common/enum';
 export class EmitEventMatchEndParamDto {
 	gameType: GameType;
 	rivalName: string;
-	rivalAvatar: string;
+	rivalAvatar: string | null;
 	rivalScore: number | null;
 	myScore: number | null;
 	isWin: boolean | null;

--- a/src/game/dto/emit-event-server-game-ready-param.dto.ts
+++ b/src/game/dto/emit-event-server-game-ready-param.dto.ts
@@ -1,6 +1,6 @@
 export class EmitEventServerGameReadyParamDto {
 	rivalNickname: string;
-	rivalAvatar: string;
+	rivalAvatar: string | null;
 	myPosition: string;
 	ball: {
 		x: number;

--- a/src/user-repository/dto/my-profile-response.dto.ts
+++ b/src/user-repository/dto/my-profile-response.dto.ts
@@ -1,7 +1,7 @@
 export type MyProfileResponseDto = {
 	id: number;
 	nickname: string;
-	avatar: string;
+	avatar: string | null;
 	statusMessage: string | null;
 	loseCount: number;
 	winCount: number;

--- a/src/user-repository/dto/user-profile-return.dto.ts
+++ b/src/user-repository/dto/user-profile-return.dto.ts
@@ -1,7 +1,7 @@
 export type UserProfileReturnDto = {
 	id: number;
 	nickname: string;
-	avatar: string;
+	avatar: string | null;
 	statusMessage: string | null;
 	loseCount: number;
 	winCount: number;

--- a/src/user-repository/entities/user.entity.ts
+++ b/src/user-repository/entities/user.entity.ts
@@ -22,9 +22,9 @@ export class User extends BaseEntity {
 	@Matches(NICKNAME_REGEXP)
 	nickname: string;
 
-	@Column({ default: null })
+	@Column({ default: null, type: 'varchar' })
 	@IsString()
-	avatar: string;
+	avatar: string | null;
 
 	@Column()
 	@IsNotEmpty()

--- a/src/users/dto/rank-user-return.dto.ts
+++ b/src/users/dto/rank-user-return.dto.ts
@@ -1,6 +1,6 @@
 export type RankUserReturnDto = {
 	nickname: string;
-	avatar: string;
+	avatar: string | null;
 	ladderScore: number;
 	ranking: number;
 };

--- a/src/users/dto/user-profile-response.dto.ts
+++ b/src/users/dto/user-profile-response.dto.ts
@@ -1,7 +1,7 @@
 export type UserProfileResponseDto = {
 	id: number;
 	nickname: string;
-	avatar: string;
+	avatar: string | null;
 	statusMessage: string | null;
 	loseCount: number;
 	winCount: number;

--- a/src/users/ranks.service.ts
+++ b/src/users/ranks.service.ts
@@ -15,15 +15,11 @@ export class RanksService {
 		@InjectRedis() private readonly redis: Redis,
 	) {}
 
-	async findRanksWithPage(page: number): Promise<RankUserResponseDto> {
+	async findRanksWithPage(): Promise<RankUserResponseDto> {
 		//userIDRanking: [userId, userId, userId, ...]
 		// 시간 재기
 		const startTime = new Date().getTime();
-		const userRanking = await this.redis.zrevrange(
-			'rankings',
-			(page - 1) * 15,
-			page * 15 - 1,
-		);
+		const userRanking = await this.redis.zrevrange('rankings', 0, 99);
 		const endTime = new Date().getTime();
 		console.log(`redis time: ${endTime - startTime}ms`);
 
@@ -34,7 +30,7 @@ export class RanksService {
 		const rankUsers: RankUserReturnDto[] = foundUsers.map(
 			(user, index) => ({
 				...user,
-				ranking: index + 1 + (page - 1) * 15,
+				ranking: index + 1,
 			}),
 		);
 		const totalItemCount = userRanking.length;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -136,10 +136,12 @@ export class UsersController {
 		@GetUser() user: User,
 		@Body('avatar') avatar: boolean,
 	) {
-		return await this.usersService.updateMyAvatar(
+		const preSignedUrl = await this.usersService.updateMyAvatar(
 			user.id,
 			user.nickname,
 			avatar,
 		);
+
+		return { preSignedUrl: preSignedUrl };
 	}
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -2,13 +2,11 @@ import {
 	BadRequestException,
 	Body,
 	Controller,
-	Delete,
 	Get,
 	Logger,
 	Param,
 	ParseIntPipe,
 	Patch,
-	Post,
 	Query,
 	UseGuards,
 } from '@nestjs/common';
@@ -88,9 +86,9 @@ export class UsersController {
 		summary: '랭킹 조회',
 		description: '레디스로부터 pagination해 랭킹 목록을 제공합니다.',
 	})
-	async paging(@Query('page', ParseIntPipe, PositiveIntPipe) page: number) {
+	async paging() {
 		// const rankResponseDto = await this.usersService.findRanksWithPage();	// 레디스 없이 DB에서 랭킹을 조회하는 코드
-		let rankResponseDto = await this.ranksServices.findRanksWithPage(page); // 레디스로부터 랭킹을 조회하는 코드
+		let rankResponseDto = await this.ranksServices.findRanksWithPage(); // 레디스로부터 랭킹을 조회하는 코드
 		if (rankResponseDto.rankUsers.length === 0) {
 			this.logger.log('랭킹이 없습니다. 랭킹을 추가합니다.');
 			rankResponseDto = await this.usersService.findRanksWithPage();
@@ -136,28 +134,12 @@ export class UsersController {
 	})
 	async updateMyAvatar(
 		@GetUser() user: User,
-		@Body('avatar') avatar: string,
+		@Body('avatar') avatar: boolean,
 	) {
-		await this.usersService.updateMyAvatar(user.id, avatar);
-	}
-
-	@UseGuards(AuthGuard('access'))
-	@Get('/s3image')
-	async getPresignedUrl(@GetUser() user: User) {
-		const presignedUrl = await this.usersService.getPresignedUrl(user.id);
-
-		return presignedUrl;
-	}
-
-	@UseGuards(AuthGuard('access'))
-	@Delete('/s3image')
-	async deleteAndGetPresignedUrl(@GetUser() user: User) {
-		const userId = user.id;
-
-		await this.usersService.deleteS3Image(userId);
-
-		const presignedUrl = await this.usersService.getPresignedUrl(userId);
-
-		return presignedUrl;
+		return await this.usersService.updateMyAvatar(
+			user.id,
+			user.nickname,
+			avatar,
+		);
 	}
 }


### PR DESCRIPTION
*노션 api 페이지 참고*
s3 이미지 업로드는 preSignedUrl을 기반으로 진행됩니다.
업로드 주체는 클라이언트이고, s3 버킷에 접근 권한을 가진 서버에서 클라이언트에게 접근 url을 발급해줍니다.

기존과 달라진 점은 **회원가입과 아바타 수정 api 에서 avatar 데이터를 boolean 값으로 받습니다**. 
true일때
* User 데이터베이스의 avatar 값을 '고정 url + 유저 닉네임 + 날짜' string 값으로 업데이트 합니다.
* preSignedUrl을 발급받아 string값을 응답 데이터로 줍니다.

false라면 
* 회원가입시에는 nickname만 업데이트하고, 수정시에는 avatar 값을 null로 업데이트합니다.
* preSignedUrl이 null인 응답 데이터를 줍니다.