### PR TITLE
fix: 라켓 업데이트 방식 변경

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -58,14 +58,19 @@ export class AuthService {
 			ret = null;
 		}
 
-		const updateRes = await this.usersRepository.update(userId, {
+		// '결과가 즉각 반영될 필요 없으니 비동기적으로 수행하도록 냅두자'라는 생각 -> await 키워드 뺌
+		this.usersRepository.update(userId, {
 			...updateUserDataDto,
 		});
-		if (updateRes.affected !== 1) {
-			throw DBUpdateFailureException(
-				`유저 ${userId}의 db 업데이트가 실패했습니다`,
-			);
-		}
+
+		// const updateRes = await this.usersRepository.update(userId, {
+		// 	...updateUserDataDto,
+		// });
+		// if (updateRes.affected !== 1) {
+		// 	throw DBUpdateFailureException(
+		// 		`유저 ${userId}의 db 업데이트가 실패했습니다`,
+		// 	);
+		// }
 
 		return ret;
 	}
@@ -96,7 +101,7 @@ export class AuthService {
 			status: UserStatus.OFFLINE,
 		});
 	}
-s
+
 
 	private async createMfaSecret() {
 		const secret = speakeasy.generateSecret({

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -43,12 +43,8 @@ export enum ChannelEventType {
 	NAME_CHANGE = 'NAME_CHANGE',
 }
 
-export enum KEYSTATUS {
+export enum RACKETSTATUS {
 	up = 'up',
 	down = 'down',
-}
-
-export enum KEYNAME {
-	arrowUp = 'arrowUp',
-	arrowDown = 'arrowDown',
+	none = 'none',
 }

--- a/src/game/dto/view-map.dto.ts
+++ b/src/game/dto/view-map.dto.ts
@@ -1,5 +1,5 @@
 // ball 변하는 값
-import { KEYNAME, KEYSTATUS } from '../../common/enum';
+import { RACKETSTATUS } from '../../common/enum';
 
 export type ball = {
 	x: number;
@@ -14,7 +14,7 @@ export type ball = {
 // racket 변하는 값
 export type racket = {
 	y: number;
-	action: KEYSTATUS | null; // up, down
+	action: RACKETSTATUS; // up, down
 };
 
 export class UpdateDto {
@@ -91,11 +91,11 @@ export class ViewMapDto {
 
 		this.racketLeft = {
 			y: canvasHeight / 2 - racketHeight / 2,
-			action: null,
+			action: RACKETSTATUS.none,
 		};
 		this.racketRight = {
 			y: canvasHeight / 2 - racketHeight / 2,
-			action: null,
+			action: RACKETSTATUS.none,
 		};
 		this.racketSize = racketSize;
 	}
@@ -139,38 +139,46 @@ export class ViewMapDto {
 			(ball.yVelocity < 0 ? ball.accel * -1 : ball.accel) * dt * dt * 0.5;
 	}
 
-	updateRacketLeft(action: KEYNAME) {
+	updateRacketLeft(action: RACKETSTATUS) {
 		const racket = this.racketLeft;
-
-		if (action === KEYNAME.arrowUp) {
-			racket.y -= this.racketSpeed;
-		} else if (action === KEYNAME.arrowDown) {
-			racket.y += this.racketSpeed;
-		}
-
-		if (racket.y <= 0) racket.y = 0;
-		if (racket.y + this.racketHeight >= this.canvasHeight)
-			racket.y = this.canvasHeight - this.racketHeight;
+		racket.action = action;
 	}
 
-	updateRacketRight(action: KEYNAME) {
+	updateRacketRight(action: RACKETSTATUS) {
 		const racket = this.racketRight;
+		racket.action = action;
+	}
 
-		if (action === KEYNAME.arrowUp) {
-			racket.y -= this.racketSpeed;
-		} else if (action === KEYNAME.arrowDown) {
-			racket.y += this.racketSpeed;
+	private async calculateRacketLocation() {
+		const racketLeft = this.racketLeft;
+		const racketRight = this.racketRight;
+
+		if (racketLeft.action == RACKETSTATUS.up) {
+			racketLeft.y -= this.racketSpeed;
+		} else if (racketLeft.action == RACKETSTATUS.down) {
+			racketLeft.y += this.racketSpeed;
 		}
 
-		if (racket.y <= 0) racket.y = 0;
-		if (racket.y + this.racketHeight >= this.canvasHeight)
-			racket.y = this.canvasHeight - this.racketHeight;
+		if (racketLeft.y <= 0) racketLeft.y = 0;
+		if (racketLeft.y + this.racketHeight >= this.canvasHeight)
+			racketLeft.y = this.canvasHeight - this.racketHeight;
+
+		if (racketRight.action == RACKETSTATUS.up) {
+			racketRight.y -= this.racketSpeed;
+		} else if (racketRight.action == RACKETSTATUS.down) {
+			racketRight.y += this.racketSpeed;
+		}
+
+		if (racketRight.y <= 0) racketRight.y = 0;
+		if (racketRight.y + this.racketHeight >= this.canvasHeight)
+			racketRight.y = this.canvasHeight - this.racketHeight;
 	}
 
 	async changes() {
 		const updateDto = this.updateDto;
 		const ball = this.ball;
 		await this.calculateNextBallLocation();
+		await this.calculateRacketLocation();
 
 		const xChange = this.ballRadius;
 		const piece = Math.abs(ball.vx / xChange);

--- a/src/game/game.gateway.ts
+++ b/src/game/game.gateway.ts
@@ -19,13 +19,7 @@ import { Server, Socket } from 'socket.io';
 import { ChannelsGateway } from '../channels/channels.gateway';
 import { SocketWithAuth } from '../common/adapter/socket-io.adapter';
 import { K } from '../common/constants';
-import {
-	GameStatus,
-	GameType,
-	KEYNAME,
-	KEYSTATUS,
-	UserStatus,
-} from '../common/enum';
+import { GameStatus, GameType, RACKETSTATUS, UserStatus } from '../common/enum';
 import {
 	EVENT_ERROR,
 	EVENT_GAME_INVITATION,
@@ -279,8 +273,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		@MessageBody()
 		data: {
 			gameId: number;
-			keyStatus: KEYSTATUS;
-			keyName: KEYNAME;
+			racketStatus: RACKETSTATUS;
 		},
 	) {
 		const user = client.user;
@@ -290,16 +283,17 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		if (!gameDto) {
 			throw WSBadRequestException(`유효하지 않은 게임입니다`);
 		}
-
 		// console.log('----When matchKeyDown event coming, racket status----');
 		// console.log(`before left racket y: ${gameDto.viewMap.racketLeft.y}`);
 		// console.log(`before right racket y: ${gameDto.viewMap.racketRight.y}`);
-		if (data.keyStatus === KEYSTATUS.down) {
-			// console.log('hi im gonna update racket');
-			if (user.id === gameDto.playerLeftId)
-				gameDto.viewMap.updateRacketLeft(data.keyName);
-			else gameDto.viewMap.updateRacketRight(data.keyName);
+		// console.log('hi im gonna update racket');
+
+		if (user.id === gameDto.playerLeftId) {
+			gameDto.viewMap.updateRacketLeft(data.racketStatus);
+		} else {
+			gameDto.viewMap.updateRacketRight(data.racketStatus);
 		}
+
 		// console.log(`after left racket y: ${gameDto.viewMap.racketLeft.y}`);
 		// console.log(`after right racket y: ${gameDto.viewMap.racketRight.y}`);
 	}

--- a/src/user-repository/users.repository.ts
+++ b/src/user-repository/users.repository.ts
@@ -199,20 +199,6 @@ export class UsersRepository extends Repository<User> {
 		});
 	}
 
-	// async deleteS3Image(userId: number) {
-	// 	const command = new DeleteObjectCommand({
-	// 		Bucket: this.s3Configure.S3_BUCKET_NAME,
-	// 		Key: `images/${userId}.jpeg`,
-	// 	});
-	//
-	// 	const response = await this.s3Configure.S3Object.send(command);
-	// 	// TODO: s3 이미지 삭제에 실패했을 때?
-	// 	if (response.$metadata.httpStatusCode !== 200) {
-	// 		console.error(response.$metadata.httpStatusCode);
-	// 		// throw new InternalServerErrorException();
-	// 	}
-	// }
-
 	private getNowDate(): string {
 		const date = new Date();
 		const year = date.getFullYear().toString();

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -109,13 +109,20 @@ export class UsersService {
 			};
 			ret = null;
 		}
-		const updateRes = await this.usersRepository.update(userId, {
+
+		// '결과가 즉각 반영될 필요 없으니 기다리지말고 비동기적으로 수행하도록 냅두자'라는 생각 -> await 키워드 뺌
+		this.usersRepository.update(userId, {
 			...updateUserDataDto,
 		});
 
-		if (updateRes.affected !== 1) {
-			throw DBUpdateFailureException(`user ${userId} update failed`);
-		}
+		// const updateRes = await this.usersRepository.update(userId, {
+		// 	...updateUserDataDto,
+		// });
+		//
+		// if (updateRes.affected !== 1) {
+		// 	throw DBUpdateFailureException(`user ${userId} update failed`);
+		// }
+
 		return ret;
 	}
 


### PR DESCRIPTION
1. 라켓 업데이트 방식 변경
- 전: 
  정보 두개(1. 라켓 키를 누르고 있는지 여부 2. 위 방향키인지 아래 방향키인지)를 받아서 바로 라켓의 위치를 계산
- 후:
  정보 한개(위 / 아래/ 안누름) 받아서 상태를 저장해놓음. 공 위치 계산할 때, 저장해놓은 상태로 라켓 위치 계산

2. 유저 이미지 업로드/수정시 **DB에 s3 path 저장**하는 부분은 굳이 기다릴 필요 없을 것 같아서 await 키워드를 뺐거든요?
비동기로 수행하라는 의도인데 await를 빼는게 맞는 방법인지는 더 공부해봐야 될 것 같음!  반박시 당신의 말이 맞음(진짜)
